### PR TITLE
Congressional/policy signals, twikit migration, risk controls, and official congressional ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,32 @@
 # Neon PostgreSQL connection string
 DATABASE_URL=postgresql://user:password@host/dbname
 
-# Alpaca Markets — stock OHLCV data (https://alpaca.markets)
+# Alpaca Markets — stock OHLCV market data (live keys). https://alpaca.markets
 ALPACA_API_KEY=your_alpaca_api_key
 ALPACA_SECRET_KEY=your_alpaca_secret_key
 
-# Finnhub — company news headlines, fallback news source (https://finnhub.io)
+# Alpaca Markets — paper trading account (used by watch.py / trade.py to place orders)
+ALPACA_PAPER_API_KEY=your_alpaca_paper_api_key
+ALPACA_PAPER_SECRET_KEY=your_alpaca_paper_secret_key
+
+# Finnhub — company news headlines / news sentiment. https://finnhub.io
 FINNHUB_API_KEY=your_finnhub_api_key
 
-# Alpha Vantage — news sentiment scores, primary source, 25 req/day free (https://www.alphavantage.co)
+# Alpha Vantage — fallback news sentiment, 25 req/day free. https://www.alphavantage.co
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
 
-# Optional: override the FastAPI backend URL for Streamlit (default: http://localhost:8000)
-# API_BASE_URL=http://localhost:8000
+# ── Optional: position sizing & risk caps (defaults shown; only set to override) ──
+# TRADE_NOTIONAL=1000        # base/fallback trade size in USD
+# MIN_NOTIONAL=500           # smallest conviction-scaled trade
+# MAX_NOTIONAL=2500          # largest conviction-scaled trade
+# MAX_OPEN_POSITIONS=15      # cap on simultaneous open positions
+# MAX_DAILY_LOSS=1500        # halt new entries past this daily loss
+
+# Optional: override the FastAPI backend URL for Streamlit/trade.py (default http://localhost:8000)
+# API_URL=http://localhost:8000
+
+# ── Twitter auth is NOT an env var ───────────────────────────────────────────
+# Tweet fetching uses twikit with browser cookies, not a key here.
+# Generate twitter_cookies.json once with:
+#   python3 test_twitter_cookies.py <auth_token> <ct0>
+# For GitHub Actions, paste that file's contents into the TWITTER_COOKIES secret.

--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,18 @@ FINNHUB_API_KEY=your_finnhub_api_key
 # Alpha Vantage — fallback news sentiment, 25 req/day free. https://www.alphavantage.co
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
 
+# Financial Modeling Prep — congressional (House+Senate) trade disclosures.
+# Free tier (250 calls/day, no card) is plenty: congress_ingest.py uses 2 calls/run.
+# https://site.financialmodelingprep.com/register
+FMP_API_KEY=your_fmp_api_key
+
 # ── Optional: position sizing & risk caps (defaults shown; only set to override) ──
 # TRADE_NOTIONAL=1000        # base/fallback trade size in USD
 # MIN_NOTIONAL=500           # smallest conviction-scaled trade
 # MAX_NOTIONAL=2500          # largest conviction-scaled trade
 # MAX_OPEN_POSITIONS=15      # cap on simultaneous open positions
 # MAX_DAILY_LOSS=1500        # halt new entries past this daily loss
+# CONGRESS_RECENCY_DAYS=4    # only trade congressional disclosures filed within N days
 
 # Optional: override the FastAPI backend URL for Streamlit/trade.py (default http://localhost:8000)
 # API_URL=http://localhost:8000

--- a/.github/workflows/congress-ingest.yml
+++ b/.github/workflows/congress-ingest.yml
@@ -1,0 +1,34 @@
+name: Congressional Trade Ingest
+
+on:
+  schedule:
+    # 3x on weekdays (~9am, 1pm, 5pm ET across EST/EDT) — disclosures trickle in
+    # all day. Each run is 2 FMP calls, so ~6 calls/day (free tier is 250/day).
+    - cron: '0 13,17,21 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    name: Pull latest House + Senate disclosures
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-watcher.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-watcher.txt
+
+      - name: Ingest congressional trades
+        run: python3 congress_ingest.py
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          FMP_API_KEY:  ${{ secrets.FMP_API_KEY }}

--- a/.github/workflows/daily_retrain.yml
+++ b/.github/workflows/daily_retrain.yml
@@ -41,6 +41,20 @@ jobs:
           echo "Prefix: ${DATABASE_URL:0:30}"
           python3 -c "import os; url=os.environ.get('DATABASE_URL',''); print('repr prefix:', repr(url[:40]))"
 
+      - name: Write Twitter cookies
+        # twikit authenticates with browser cookies instead of a paid API key.
+        # Store the contents of a locally generated twitter_cookies.json
+        # (see test_twitter_cookies.py) as the TWITTER_COOKIES repo secret.
+        env:
+          TWITTER_COOKIES: ${{ secrets.TWITTER_COOKIES }}
+        run: |
+          if [ -n "$TWITTER_COOKIES" ]; then
+            printf '%s' "$TWITTER_COOKIES" > twitter_cookies.json
+            echo "Wrote twitter_cookies.json ($(wc -c < twitter_cookies.json) bytes)"
+          else
+            echo "WARNING: TWITTER_COOKIES secret not set — tweet fetching will be skipped."
+          fi
+
       - name: Fetch fresh data (tweets + stocks + news)
         env:
           DATABASE_URL:          ${{ secrets.DATABASE_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.env.bak
 __pycache__/
 test.db
 session.tw_session

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 test.db
 session.tw_session
 cookies.json
+twitter_cookies.json
 streamlit.log
 *.log
 .streamlit/secrets.toml

--- a/22Features.md
+++ b/22Features.md
@@ -1,0 +1,30 @@
+The 22 Features Going Into the Model
+Sentiment
+
+sentiment_score — VADER compound score (-1 to +1)
+finbert_score — FinBERT financial-domain score (-1 to +1)
+sentiment_magnitude — absolute value of VADER, captures extreme tweets regardless of direction
+Tweet substance
+
+tweet_length, word_count — longer more deliberate tweets carry different signal than short ones
+Engagement (all log-scaled so one viral tweet doesn't dominate)
+
+log_likes, log_retweets, log_views, log_replies
+engagement_rate — (likes + retweets + replies) / views, normalized for audience size
+Timing
+
+tweet_hour — what hour it was posted
+is_premarket — whether it was posted before NYSE open (9:30am ET)
+Market state at tweet time
+
+rsi_at_tweet — momentum indicator (0–100)
+rsi_overbought — flag: RSI > 70
+rsi_oversold — flag: RSI < 30
+atr_at_tweet — how volatile the stock already was that day
+vix_at_tweet — how fearful the overall market was
+days_to_earnings — how close to a quarterly earnings report
+news_sentiment_score — average headline sentiment for that ticker that day
+prev_day_direction — did the stock go up or down yesterday (momentum)
+Categorical (one-hot encoded)
+
+refined_sentiment, tone_category, tweet_type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,15 @@ PostgreSQL.
 - `relationship_analysis.py` — builds the `ceo_ticker_relationships` registry (per-CEO, per-topic best ticker + tightness score)
 - `app.py` — Streamlit dashboard
 
-**Signal flow (watch.py):** new tweet → `get_tweet_topic()` → if `congressional_trade`, parse ticker/direction directly (fast path, bypasses ML); else registry lookup for best ticker → ML prediction → confidence gate (≥55%) → trade if market open, else queue for next open.
+**Signal flow (watch.py):** new tweet → `get_tweet_topic()` → if `congressional_trade` or `short_report`, parse ticker/direction directly (fast path, bypasses ML); else registry lookup for best ticker → ML prediction → confidence gate (≥55%) → trade if market open, else queue for next open.
 
-**Special account types:** congressional-trade aggregators (`unusual_whales`, `capitoltrades`) and policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
+**Exit horizon:** the model predicts *next-day* direction, so every entry is registered in `managed_positions` with an `exit_after` time (next trading day, 15:30 ET) and closed by `close_due_positions()` on the first poll cycle past that time. Without this, positions would otherwise only close on a reversing signal.
+
+**Double-trade guard:** `_execute_signal()` skips a signal if `paper_trades` already has a `placed` row for the same (ceo, ticker, tweet_date) — protects against retries and against the Render worker + GitHub Actions both processing the same tweet.
+
+**Special account types:**
+- congressional-trade aggregators (`unusual_whales`, `capitoltrades`) and policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
+- short-seller accounts (`HindenburgRes`, `muddywaters`, etc. — see `_SHORT_SELLER_HANDLES`) get a `short_report` fast-path: a report naming a ticker is a fixed DOWN signal, since these posts move stocks sharply on publication.
 
 **Weekend handling:** tweet dates on weekends shift to the following Monday for stock correlation.
 
@@ -58,6 +64,7 @@ Neon PostgreSQL (SQLAlchemy). Key tables:
 - `news_sentiment_cache` — cached Finnhub news sentiment per (ticker, date)
 - `ceo_ticker_relationships` — registry of best (ceo, topic) → ticker with `tightness_score` (built by `relationship_analysis.py`)
 - `signal_queue` — signals found outside market hours, executed at next open (`watch.py`)
-- `paper_trades` — log of every placed/skipped/errored trade
+- `managed_positions` — open positions with their scheduled next-day exit time (`watch.py`)
+- `paper_trades` — log of every placed/skipped/errored/exit trade
 - `watcher_state` — per-CEO last-seen tweet watermark and counters
 - `tweets` / `stocks` — legacy tables used by the original FastAPI/Streamlit flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,32 +15,49 @@ uvicorn main:app --reload
 streamlit run app.py
 
 # Environment variables required in .env
-# DATABASE_URL, ALPACA_API_KEY, ALPACA_SECRET_KEY, FINNHUB_API_KEY
+# DATABASE_URL, ALPACA_API_KEY, ALPACA_SECRET_KEY,
+# ALPACA_PAPER_API_KEY, ALPACA_PAPER_SECRET_KEY, FINNHUB_API_KEY
 ```
 
-No test framework or linter is currently configured.
+**Twitter auth:** Tweet fetching uses the `twikit` library, which authenticates with
+browser cookies (no paid API). Generate `twitter_cookies.json` once with
+`python test_twitter_cookies.py <auth_token> <ct0>` (the file is gitignored). In
+GitHub Actions the same JSON is supplied via the `TWITTER_COOKIES` repo secret.
+
+No linter is configured. Tests live in `tests/` and run with `pytest`.
 
 ## Architecture
 
-MoneyMaker correlates CEO tweets with stock market data. It fetches tweets via the `tweety-ns` library, runs sentiment analysis, fetches corresponding stock data from Alpaca, merges the results, and stores them in a Neon PostgreSQL database.
+MoneyMaker is an ML-driven trading-signal pipeline: it ingests tweets from CEOs,
+congressional-trade aggregators, and policy accounts, scores them, predicts a
+short-term stock direction, and places Alpaca paper trades. Data is stored in Neon
+PostgreSQL.
 
 **Core files:**
-- `main.py` — FastAPI app with all endpoints, SQLAlchemy models (`TweetRecord`, `StockRecord`, `MergedRecord`), and the primary orchestration endpoint `POST /process/all`
-- `processor.py` — `DataProcessor` class that calls tweety-ns (Twitter) and alpaca-py (stocks); contains a runtime monkey-patch to bypass a tweety-ns animation key index error
-- `classifier.py` — TextBlob-based sentiment utilities: `get_refined_sentiment()`, `get_tone_category()`, `get_tweet_type()`
-- `app.py` — Streamlit dashboard with 4 tabs: Pull Tweets, Pull Stock Data, Pull Merged Data, ATR Analysis
+- `main.py` — FastAPI app with endpoints and SQLAlchemy models; orchestration endpoint `POST /process/all`
+- `processor.py` — `DataProcessor`: fetches tweets via `twikit` (cookie auth) and stock bars via `alpaca-py`. The market-data client accepts live or paper keys (free IEX feed)
+- `classifier.py` — VADER + FinBERT sentiment, tone/type helpers, the `get_tweet_topic()` bucket classifier, and `parse_congressional_trade()` (extracts ticker + buy/sell direction from disclosure posts)
+- `model/predict.py` — builds the 22-feature vector and runs the trained model (`model/trained_model.pkl`); see `22Features.md`
+- `run_pipeline.py` — daily ingestion: fetch tweets+stocks+news for every target, write `merged_data`
+- `watch.py` — intraday watcher: polls accounts, evaluates signals, places paper trades. Two-tier polling (fast lane for `HIGH_PRIORITY_HANDLES`, full sweep otherwise). `--db-only` mode (GitHub Actions) reads `merged_data` instead of fetching Twitter
+- `discover.py` — candidate-discovery pipeline; tests `candidates.csv` accounts for tweet→price links and promotes them to the registry (local only — needs cookies)
+- `targets.py` — single source of truth for handle→ticker mappings (`CEO_TARGETS`, `HANDLE_TO_TICKER`)
+- `relationship_analysis.py` — builds the `ceo_ticker_relationships` registry (per-CEO, per-topic best ticker + tightness score)
+- `app.py` — Streamlit dashboard
 
-**Data flow:** User inputs CEO handle + ticker + date range → `DataProcessor` fetches tweets and stock bars → `Classifier` annotates sentiment/tone/type → records merged and saved to Neon → returned to UI.
+**Signal flow (watch.py):** new tweet → `get_tweet_topic()` → if `congressional_trade`, parse ticker/direction directly (fast path, bypasses ML); else registry lookup for best ticker → ML prediction → confidence gate (≥55%) → trade if market open, else queue for next open.
 
-**CEO→ticker mappings** are hardcoded in `processor.py`: elonmusk→TSLA, tim_cook→AAPL, satyanadella→MSFT, sundarpichai→GOOGL, MichaelDell→DELL.
+**Special account types:** congressional-trade aggregators (`unusual_whales`, `capitoltrades`) and policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
 
-**Weekend handling:** Tweet dates that fall on weekends are automatically shifted to the following Monday for stock price correlation.
-
-**ATR Analysis:** The Streamlit UI computes a 14-day rolling Average True Range to correlate high-sentiment tweet periods with stock volatility.
+**Weekend handling:** tweet dates on weekends shift to the following Monday for stock correlation.
 
 ## Database Schema
 
-Three tables (SQLAlchemy + Neon PostgreSQL):
-- `tweets` — id, date, ceo, text, sentiment_score, refined_sentiment
-- `stocks` — id, symbol, timestamp, open, high, low, close, volume
-- `merged_data` — id, date, ceo, tweet_text, sentiment_score, refined_sentiment, tone_category, tweet_type, stock_ticker, stock_close, stock_volume, stock_open_close_diff
+Neon PostgreSQL (SQLAlchemy). Key tables:
+- `merged_data` — the training/inference table: one row per tweet with sentiment, engagement, technicals, news sentiment, and the `next_day_direction` label (see `run_pipeline.py` `MergedRecord`)
+- `news_sentiment_cache` — cached Finnhub news sentiment per (ticker, date)
+- `ceo_ticker_relationships` — registry of best (ceo, topic) → ticker with `tightness_score` (built by `relationship_analysis.py`)
+- `signal_queue` — signals found outside market hours, executed at next open (`watch.py`)
+- `paper_trades` — log of every placed/skipped/errored trade
+- `watcher_state` — per-CEO last-seen tweet watermark and counters
+- `tweets` / `stocks` — legacy tables used by the original FastAPI/Streamlit flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ PostgreSQL.
 
 **Double-trade guard:** `_execute_signal()` skips a signal if `paper_trades` already has a `placed` row for the same (ceo, ticker, tweet_date) — protects against retries and against the Render worker + GitHub Actions both processing the same tweet.
 
+**Position sizing & risk caps:** trade size is conviction-scaled by `position_notional()` (blends model confidence and tightness onto [`MIN_NOTIONAL`, `MAX_NOTIONAL`]). Before opening a new position, `risk_gate()` enforces `MAX_OPEN_POSITIONS` and a `MAX_DAILY_LOSS` kill switch (via Alpaca equity vs. prior close). All sizing/risk limits are env-overridable.
+
 **Special account types:**
 - congressional-trade aggregators (`unusual_whales`, `capitoltrades`) and policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
 - short-seller accounts (`HindenburgRes`, `muddywaters`, etc. — see `_SHORT_SELLER_HANDLES`) get a `short_report` fast-path: a report naming a ticker is a fixed DOWN signal, since these posts move stocks sharply on publication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ PostgreSQL.
 - `classifier.py` — VADER + FinBERT sentiment, tone/type helpers, the `get_tweet_topic()` bucket classifier, and `parse_congressional_trade()` (extracts ticker + buy/sell direction from disclosure posts)
 - `model/predict.py` — builds the 22-feature vector and runs the trained model (`model/trained_model.pkl`); see `22Features.md`
 - `run_pipeline.py` — daily ingestion: fetch tweets+stocks+news for every target, write `merged_data`
+- `congress_ingest.py` — pulls latest House+Senate STOCK Act disclosures from Financial Modeling Prep (free tier, `FMP_API_KEY`) into the `congress_trades` table. No Twitter/PDF needed — structured ticker/direction/date/amount. 2 API calls per run
 - `watch.py` — intraday watcher: polls accounts, evaluates signals, places paper trades. Two-tier polling (fast lane for `HIGH_PRIORITY_HANDLES`, full sweep otherwise). `--db-only` mode (GitHub Actions) reads `merged_data` instead of fetching Twitter
 - `discover.py` — candidate-discovery pipeline; tests `candidates.csv` accounts for tweet→price links and promotes them to the registry (local only — needs cookies)
 - `targets.py` — single source of truth for handle→ticker mappings (`CEO_TARGETS`, `HANDLE_TO_TICKER`)
@@ -53,8 +54,10 @@ PostgreSQL.
 
 **Position sizing & risk caps:** trade size is conviction-scaled by `position_notional()` (blends model confidence and tightness onto [`MIN_NOTIONAL`, `MAX_NOTIONAL`]). Before opening a new position, `risk_gate()` enforces `MAX_OPEN_POSITIONS` and a `MAX_DAILY_LOSS` kill switch (via Alpaca equity vs. prior close). All sizing/risk limits are env-overridable.
 
-**Special account types:**
-- congressional-trade aggregators (`unusual_whales`, `capitoltrades`) and policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
+**Congressional trades (primary path):** sourced from official disclosures via `congress_ingest.py` → `congress_trades` table → `poll_congress_trades()` in the watcher, which builds `congressional_trade` signals (Purchase→Up, Sale→Down) and runs them through `_execute_signal()` so they get sizing, risk caps, the next-day exit, and idempotency. Gated by `CONGRESS_RECENCY_DAYS` so only freshly disclosed trades are acted on. This replaces the old, fragile tweet path; the `parse_congressional_trade()` tweet parser remains only as a fallback for any aggregator tweets still ingested.
+
+**Special account types (tweet path):**
+- policy accounts (`realDonaldTrump`, `POTUS`, `ScottBessent`) are exempt from the sentiment gate in `passes_gates()` — their posts are factual/low-sentiment, so the signal comes from content, not tone.
 - short-seller accounts (`HindenburgRes`, `muddywaters`, etc. — see `_SHORT_SELLER_HANDLES`) get a `short_report` fast-path: a report naming a ticker is a fixed DOWN signal, since these posts move stocks sharply on publication.
 
 **Weekend handling:** tweet dates on weekends shift to the following Monday for stock correlation.
@@ -67,6 +70,7 @@ Neon PostgreSQL (SQLAlchemy). Key tables:
 - `ceo_ticker_relationships` — registry of best (ceo, topic) → ticker with `tightness_score` (built by `relationship_analysis.py`)
 - `signal_queue` — signals found outside market hours, executed at next open (`watch.py`)
 - `managed_positions` — open positions with their scheduled next-day exit time (`watch.py`)
+- `congress_trades` — structured House/Senate disclosures from `congress_ingest.py`; the watcher trades unprocessed rows
 - `paper_trades` — log of every placed/skipped/errored/exit trade
 - `watcher_state` — per-CEO last-seen tweet watermark and counters
 - `tweets` / `stocks` — legacy tables used by the original FastAPI/Streamlit flow

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MoneyMaker answers that question with real data. It collects tweets from 24 high
 | Frontend | Streamlit, Plotly |
 | ML / NLP | scikit-learn, VADER, FinBERT (HuggingFace `ProsusAI/finbert`), pandas, numpy |
 | Database | Neon (serverless PostgreSQL), psycopg2 |
-| Data sources | Twitter/X (tweety-ns), Alpaca Markets, Alpha Vantage, Finnhub, yfinance |
+| Data sources | Twitter/X (twikit, cookie auth), Alpaca Markets, Alpha Vantage, Finnhub, yfinance |
 | CI/CD | GitHub Actions (scheduled daily retraining) |
 | Hosting | Streamlit Community Cloud |
 
@@ -142,10 +142,17 @@ pip install -r requirements.txt
 
 # 2. Create .env in the project root (see .env.example)
 DATABASE_URL=your_neon_postgres_connection_url
-ALPACA_API_KEY=your_alpaca_api_key
+ALPACA_API_KEY=your_alpaca_api_key                  # market data (live keys)
 ALPACA_SECRET_KEY=your_alpaca_secret_key
+ALPACA_PAPER_API_KEY=your_alpaca_paper_api_key      # paper trading (watch.py / trade.py)
+ALPACA_PAPER_SECRET_KEY=your_alpaca_paper_secret_key
 FINNHUB_API_KEY=your_finnhub_api_key          # optional
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key  # optional
+
+# 2b. Generate Twitter cookies for twikit (no paid API needed).
+#     Grab auth_token and ct0 from your logged-in x.com browser cookies, then:
+python3 test_twitter_cookies.py <auth_token> <ct0>   # writes twitter_cookies.json
+#     For GitHub Actions, paste the file's contents into the TWITTER_COOKIES repo secret.
 
 # 3. Start the FastAPI backend
 uvicorn main:app --reload           # http://localhost:8000 · docs at /docs

--- a/README.md
+++ b/README.md
@@ -171,6 +171,35 @@ python3 run_pipeline.py --pages 50  # historical backfill
 python3 -m pytest tests/ -v
 ```
 
+### Twitter cookie setup
+
+Tweet fetching uses [twikit](https://github.com/d60/twikit), which authenticates
+with browser cookies instead of a paid X API key. Without valid cookies the
+pipeline runs but ingests **no new tweets** (it falls back to whatever is already
+in `merged_data`).
+
+1. **Use a dedicated burner X account** — the `auth_token` cookie is full account
+   access (no password/2FA gate), and automated access can get an account
+   rate-limited or suspended. Don't use your personal account.
+2. Log into x.com in a browser, open DevTools → Application/Storage → Cookies →
+   `https://x.com`, and copy the **`auth_token`** and **`ct0`** values.
+3. Generate and validate the cookie file:
+   ```bash
+   python3 test_twitter_cookies.py <auth_token> <ct0>   # writes twitter_cookies.json
+   ```
+4. For GitHub Actions, paste the contents of `twitter_cookies.json` into a repo
+   secret named **`TWITTER_COOKIES`** (the daily pipeline writes it back to a file).
+
+**Cookies expire** (on logout or X's rotation) — when fetching suddenly returns
+nothing, regenerate them. `processor.py` now logs a clear error and
+`run_pipeline.py` exits non-zero in that case, so the failure is visible instead
+of silent.
+
+> **Datacenter-IP note:** cookies generated on your home IP and used from
+> GitHub Actions / Render may occasionally be flagged. If that happens, run
+> ingestion locally (cron/launchd, where the IP matches the browser session) and
+> keep the cloud watcher in `--db-only` mode reading `merged_data`.
+
 ---
 
 ## Tests

--- a/candidates.csv
+++ b/candidates.csv
@@ -44,7 +44,7 @@ fchollet,Francois Chollet,tech_executive,Google AI researcher - AI benchmark and
 emollick,Ethan Mollick,tech_executive,Wharton AI professor - AI adoption signals
 zuck,Mark Zuckerberg,tech_executive,Meta CEO - product and business signals
 jonyivegroupie,Jony Ive,tech_executive,Former Apple designer - Apple product signals
-BobIger,Robert Iger,tech_executive,Disney CEO - already tracked as RobertIger
+# BobIger removed — Robert Iger already tracked as RobertIger in main targets
 Piyasena,Elon Musk,tech_executive,Already tracked as elonmusk
 naval,Naval Ravikant,investor,AngelList founder - tech and crypto sentiment
 paulg,Paul Graham,investor,YCombinator - startup and tech signals
@@ -105,3 +105,8 @@ RobertKiyosaki,Robert Kiyosaki,investor,Rich Dad Poor Dad - gold and crypto sent
 mikenovogratz,Mike Novogratz,crypto,Galaxy Digital CEO - institutional crypto
 GrayscaleBTC,Grayscale,crypto,Bitcoin trust - institutional crypto flows
 coinbasedevs,Coinbase,tech_executive,Already tracked as brian_armstrong
+quiver_quant,Quiver Quantitative,congressional,SUSPENDED on X - skip
+capitoltrades,Capitol Trades,congressional,Congressional STOCK Act disclosure aggregator - posts every disclosed trade
+realDonaldTrump,Donald Trump,policy,US President - tariff announcements and trade policy move entire sectors immediately
+POTUS,POTUS (official),policy,Official White House account - executive orders and policy statements
+ScottBessent,Scott Bessent,policy,US Treasury Secretary - dollar policy rates and debt commentary move TLT and XLF

--- a/classifier.py
+++ b/classifier.py
@@ -201,8 +201,50 @@ _NON_TICKERS = {
     "REP", "SEN", "THE", "AND", "FOR", "LLC", "INC", "ETF", "USA",
     "USD", "NYSE", "SEC", "ACT", "NEW", "OLD", "BUY", "SELL", "SOLD",
     "STOCK", "SHARES", "NET", "TAX", "TRADE", "ALERT", "PURCHASED",
-    "BOUGHT", "DIVEST", "WORTH",
+    "BOUGHT", "DIVEST", "WORTH", "CEO", "CFO", "DOJ", "FBI", "SHORT",
 }
+
+# Short-seller research accounts. A report from one of these is a strong DOWN
+# signal on the named ticker regardless of the post's sentiment tone.
+_SHORT_SELLER_HANDLES = {
+    "HindenburgRes", "muddywaters", "CitronResearch", "GothamResearch",
+    "PrestigeEconom1", "FuzzyPandaShort", "ScorpionCap", "WolfpackReports",
+    "BonitasResearch", "ViceroyResearch", "SprucePointCap",
+}
+
+_SHORT_REPORT_MARKERS = [
+    "short", "we are short", "strong sell", "new report", "investigation",
+    "fraud", "accounting", "overvalued", "scheme", "ponzi", "misleading",
+    "scam", "red flag", "downside", "going to zero", "put options",
+]
+
+# "(NASDAQ: XYZ)", "(NYSE: ABC)", "(NYSE:ABC)" etc.
+_EXCHANGE_TICKER_RE = re.compile(
+    r'\((?:NASDAQ|NYSE|NYSEARCA|AMEX|OTC)[:\s]+([A-Za-z]{1,5})\)', re.IGNORECASE
+)
+
+
+def parse_short_seller_report(text: str) -> dict | None:
+    """
+    Parse a short-seller research post (Hindenburg, Muddy Waters, etc.).
+    A report is always a DOWN signal on the named ticker.
+
+    Returns {'ticker': str, 'direction': 'Down'} or None.
+    """
+    if not any(m in text.lower() for m in _SHORT_REPORT_MARKERS):
+        return None
+
+    m = _CASHTAG_RE.search(text)
+    if m and m.group(1) not in _NON_TICKERS:
+        return {"ticker": m.group(1), "direction": "Down"}
+
+    m = _EXCHANGE_TICKER_RE.search(text)
+    if m:
+        ticker = m.group(1).upper()
+        if ticker not in _NON_TICKERS:
+            return {"ticker": ticker, "direction": "Down"}
+
+    return None
 
 
 def parse_congressional_trade(text: str) -> dict | None:
@@ -268,10 +310,11 @@ _COMPETITOR_KEYWORDS = {
 
 def get_tweet_topic(text: str, ceo_handle: str = None) -> str:
     """
-    Classify a tweet into one of eight topic buckets.
+    Classify a tweet into one of nine topic buckets.
 
     Priority order (first match wins):
-        congressional_trade — disclosure post from unusual_whales / quiver_quant
+        congressional_trade — disclosure post from unusual_whales / capitoltrades
+        short_report        — short-seller research post (DOWN signal)
         company_ops         — about the CEO's own company / products
         crypto              — cryptocurrency content
         ai_tech             — AI / ML / compute content
@@ -280,8 +323,9 @@ def get_tweet_topic(text: str, ceo_handle: str = None) -> str:
         macro_market        — macroeconomic / regulatory content
         personal            — everything else (no expected market signal)
 
-    Returns one of: 'congressional_trade', 'company_ops', 'crypto', 'ai_tech',
-                    'competitor', 'policy', 'macro_market', 'personal'
+    Returns one of: 'congressional_trade', 'short_report', 'company_ops',
+                    'crypto', 'ai_tech', 'competitor', 'policy',
+                    'macro_market', 'personal'
     """
     if not text or len(text.strip()) < 15:
         return "personal"
@@ -301,30 +345,38 @@ def get_tweet_topic(text: str, ceo_handle: str = None) -> str:
         if is_trade:
             return "congressional_trade"
 
-    # 2 — Company-specific
+    # 2 — Short-seller report (DOWN signal, bypasses ML). Only fires for known
+    # short-seller accounts that name a ticker in a report-like post.
+    if ceo_handle in _SHORT_SELLER_HANDLES:
+        if any(m in t for m in _SHORT_REPORT_MARKERS) and (
+            _CASHTAG_RE.search(text) or _EXCHANGE_TICKER_RE.search(text)
+        ):
+            return "short_report"
+
+    # 3 — Company-specific
     if ceo_handle and ceo_handle in _CEO_COMPANY_KEYWORDS:
         if any(kw in t for kw in _CEO_COMPANY_KEYWORDS[ceo_handle]):
             return "company_ops"
 
-    # 3 — Crypto (before AI so "bitcoin mining" → crypto not ai_tech)
+    # 4 — Crypto (before AI so "bitcoin mining" → crypto not ai_tech)
     if any(kw in t for kw in _CRYPTO_KEYWORDS):
         return "crypto"
 
-    # 4 — AI/tech
+    # 5 — AI/tech
     if any(kw in t for kw in _AI_KEYWORDS):
         return "ai_tech"
 
-    # 5 — Named competitor
+    # 6 — Named competitor
     if ceo_handle and ceo_handle in _COMPETITOR_KEYWORDS:
         if any(kw in t for kw in _COMPETITOR_KEYWORDS[ceo_handle]):
             return "competitor"
 
-    # 6 — Policy (tariffs, sanctions, executive orders) — for presidential/treasury accounts
+    # 7 — Policy (tariffs, sanctions, executive orders) — for presidential/treasury accounts
     if ceo_handle and ceo_handle in _POLICY_ACCOUNT_HANDLES:
         if any(kw in t for kw in _POLICY_KEYWORDS):
             return "policy"
 
-    # 7 — Macro/market
+    # 8 — Macro/market
     if any(kw in t for kw in _MACRO_KEYWORDS):
         return "macro_market"
 

--- a/classifier.py
+++ b/classifier.py
@@ -1,3 +1,4 @@
+import re
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
 _analyzer = SentimentIntensityAnalyzer()
@@ -166,6 +167,93 @@ _MACRO_KEYWORDS = [
     "bear market", "bull market", "market crash",
 ]
 
+_POLICY_KEYWORDS = [
+    "tariff", "tariffs", "sanction", "sanctions", "executive order",
+    "trade deal", "trade war", "trade agreement", "import duty", "export ban",
+    "chip ban", "semiconductor restriction", "china ban", "decoupling",
+    "defense budget", "defense spending", "military spending", "pentagon budget",
+    "nato spending", "interest rate", "federal reserve", "rate hike", "rate cut",
+    "debt ceiling", "government shutdown", "infrastructure bill", "stimulus",
+    "tax cut", "tax hike", "capital gains", "corporate tax",
+]
+
+# Accounts whose macro content should be classified as policy rather than macro_market
+# so the relationship registry tests sector ETFs instead of SPY/QQQ alone
+_POLICY_ACCOUNT_HANDLES = {
+    "realDonaldTrump", "POTUS", "ScottBessent", "stevenmnuchin1",
+}
+
+_CONGRESSIONAL_MARKERS = [
+    "rep.", "sen.", "senator", "representative", "congress",
+    "disclosure", "stock act", "trade alert", "purchased shares",
+    # Known names that appear in disclosure aggregator posts
+    "pelosi", "tuberville", "crenshaw", "greene", "ocasio-cortez",
+]
+
+# Matches "$50K - $100K", "$1M-$5M", "$1,001 - $15,000" etc.
+_AMOUNT_RE  = re.compile(r'\$[\d,]+[KMB]?\s*[-–to]+\s*\$[\d,]+[KMB]?', re.IGNORECASE)
+# Matches cashtag like $TSLA, $NVDA (1-5 uppercase letters)
+_CASHTAG_RE = re.compile(r'\$([A-Z]{1,5})\b')
+# Matches "of TSLA" or "of $TSLA"
+_OF_TICKER_RE = re.compile(r'\bof\s+\$?([A-Z]{1,5})\b')
+# Non-ticker uppercase words to filter out
+_NON_TICKERS = {
+    "REP", "SEN", "THE", "AND", "FOR", "LLC", "INC", "ETF", "USA",
+    "USD", "NYSE", "SEC", "ACT", "NEW", "OLD", "BUY", "SELL", "SOLD",
+    "STOCK", "SHARES", "NET", "TAX", "TRADE", "ALERT", "PURCHASED",
+    "BOUGHT", "DIVEST", "WORTH",
+}
+
+
+def parse_congressional_trade(text: str) -> dict | None:
+    """
+    Parse a congressional trade disclosure post from unusual_whales
+    or capitoltrades.
+
+    Returns {'ticker': str, 'direction': 'Up'|'Down'} or None.
+    """
+    t = text.lower()
+
+    # Must look like a congressional disclosure
+    has_marker = any(m in t for m in _CONGRESSIONAL_MARKERS)
+    has_amount  = bool(_AMOUNT_RE.search(text))
+    if not has_marker and not has_amount:
+        return None
+
+    # Direction
+    is_buy  = any(w in t for w in ["bought", "purchased", "acquired", "purchase"])
+    is_sell = any(w in t for w in ["sold", "sale", "divested", "divest", "sell"])
+    if not (is_buy or is_sell):
+        return None
+    direction = "Up" if is_buy else "Down"
+
+    # Ticker — prefer cashtag ($TSLA), then "of TICKER", then nearest caps word
+    m = _CASHTAG_RE.search(text)
+    if m:
+        ticker = m.group(1)
+        if ticker not in _NON_TICKERS:
+            return {"ticker": ticker, "direction": direction}
+
+    m = _OF_TICKER_RE.search(text)
+    if m:
+        ticker = m.group(1)
+        if ticker not in _NON_TICKERS:
+            return {"ticker": ticker, "direction": direction}
+
+    # Last resort: caps word within 60 chars of dollar amount
+    amount_m = _AMOUNT_RE.search(text)
+    if amount_m:
+        start   = max(0, amount_m.start() - 60)
+        end     = min(len(text), amount_m.end() + 60)
+        context = text[start:end]
+        candidates = [c for c in re.findall(r'\b([A-Z]{2,5})\b', context)
+                      if c not in _NON_TICKERS]
+        if candidates:
+            return {"ticker": candidates[-1], "direction": direction}
+
+    return None
+
+
 _COMPETITOR_KEYWORDS = {
     # Maps CEO handle → list of competitor names/tickers that signal competitor topic
     "elonmusk":     ["rivian", "rivn", "lucid", "lcid", "nio", "byd", "waymo"],
@@ -180,18 +268,20 @@ _COMPETITOR_KEYWORDS = {
 
 def get_tweet_topic(text: str, ceo_handle: str = None) -> str:
     """
-    Classify a tweet into one of six topic buckets.
+    Classify a tweet into one of eight topic buckets.
 
     Priority order (first match wins):
-        company_ops  — about the CEO's own company / products
-        crypto       — cryptocurrency content
-        ai_tech      — AI / ML / compute content
-        competitor   — mentions a named competitor
-        macro_market — macroeconomic / regulatory content
-        personal     — everything else (no expected market signal)
+        congressional_trade — disclosure post from unusual_whales / quiver_quant
+        company_ops         — about the CEO's own company / products
+        crypto              — cryptocurrency content
+        ai_tech             — AI / ML / compute content
+        competitor          — mentions a named competitor
+        policy              — tariffs, sanctions, executive orders (policy accounts)
+        macro_market        — macroeconomic / regulatory content
+        personal            — everything else (no expected market signal)
 
-    Returns one of: 'company_ops', 'crypto', 'ai_tech',
-                    'competitor', 'macro_market', 'personal'
+    Returns one of: 'congressional_trade', 'company_ops', 'crypto', 'ai_tech',
+                    'competitor', 'policy', 'macro_market', 'personal'
     """
     if not text or len(text.strip()) < 15:
         return "personal"
@@ -203,25 +293,38 @@ def get_tweet_topic(text: str, ceo_handle: str = None) -> str:
     if len(stripped) < 10:
         return "personal"
 
-    # 1 — Company-specific (highest priority)
+    # 1 — Congressional trade disclosure (highest priority — bypasses ML)
+    has_marker = any(m in t for m in _CONGRESSIONAL_MARKERS)
+    has_amount  = bool(_AMOUNT_RE.search(text))
+    if has_marker and has_amount:
+        is_trade = any(w in t for w in ["bought", "purchased", "acquired", "sold", "divest"])
+        if is_trade:
+            return "congressional_trade"
+
+    # 2 — Company-specific
     if ceo_handle and ceo_handle in _CEO_COMPANY_KEYWORDS:
         if any(kw in t for kw in _CEO_COMPANY_KEYWORDS[ceo_handle]):
             return "company_ops"
 
-    # 2 — Crypto (before AI so "bitcoin mining" → crypto not ai_tech)
+    # 3 — Crypto (before AI so "bitcoin mining" → crypto not ai_tech)
     if any(kw in t for kw in _CRYPTO_KEYWORDS):
         return "crypto"
 
-    # 3 — AI/tech
+    # 4 — AI/tech
     if any(kw in t for kw in _AI_KEYWORDS):
         return "ai_tech"
 
-    # 4 — Named competitor
+    # 5 — Named competitor
     if ceo_handle and ceo_handle in _COMPETITOR_KEYWORDS:
         if any(kw in t for kw in _COMPETITOR_KEYWORDS[ceo_handle]):
             return "competitor"
 
-    # 5 — Macro/market
+    # 6 — Policy (tariffs, sanctions, executive orders) — for presidential/treasury accounts
+    if ceo_handle and ceo_handle in _POLICY_ACCOUNT_HANDLES:
+        if any(kw in t for kw in _POLICY_KEYWORDS):
+            return "policy"
+
+    # 7 — Macro/market
     if any(kw in t for kw in _MACRO_KEYWORDS):
         return "macro_market"
 
@@ -351,5 +454,27 @@ CEO_TOPIC_UNIVERSE = {
         "company_ops":  ["NVDA", "AMD", "INTC", "QCOM", "SMCI", "ARM"],
         "ai_tech":      ["NVDA", "SMCI", "AMD"],
         "macro_market": ["SPY", "SOXX"],
+    },
+    # Congressional trade aggregators — broad ETF universe; ticker parsed directly from post
+    "unusual_whales": {
+        "congressional_trade": ["SPY", "QQQ", "XLF", "XLE", "XLK", "XLI", "ITA", "SOXX", "TLT", "GLD"],
+        "macro_market":        ["SPY", "QQQ", "TLT", "GLD", "XLF"],
+    },
+    "capitoltrades": {
+        "congressional_trade": ["SPY", "QQQ", "XLF", "XLE", "XLK", "XLI", "ITA", "SOXX", "TLT", "GLD"],
+    },
+    # Presidential / Treasury — policy tweets map to sector ETFs by theme
+    "realDonaldTrump": {
+        "policy":       ["XLI", "SOXX", "XLB", "SLX", "XLE", "ITA", "TLT", "GLD", "SPY", "EEM"],
+        "crypto":       ["COIN", "MSTR", "MARA", "RIOT"],
+        "macro_market": ["SPY", "TLT", "GLD", "XLF", "DXY"],
+    },
+    "POTUS": {
+        "policy":       ["XLI", "SOXX", "XLB", "SLX", "XLE", "ITA", "TLT", "GLD", "SPY", "EEM"],
+        "macro_market": ["SPY", "TLT", "GLD", "XLF"],
+    },
+    "ScottBessent": {
+        "policy":       ["TLT", "XLF", "GLD", "DXY", "SPY", "XLI"],
+        "macro_market": ["TLT", "XLF", "GLD", "SPY"],
     },
 }

--- a/congress_ingest.py
+++ b/congress_ingest.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Congressional trade ingester.
+
+Pulls the latest House & Senate STOCK Act disclosures from Financial Modeling
+Prep (free tier) and writes structured rows into the `congress_trades` table.
+The watcher (watch.py) then trades newly disclosed trades via poll_congress_trades().
+
+This replaces the old, fragile path of scraping aggregator tweets
+(capitoltrades / unusual_whales) and regex-parsing them — the data here is
+already structured (ticker, buy/sell, dates, amount) and needs no Twitter auth.
+
+Free-tier constraints (handled here):
+  - only page 0 of each *-latest feed is accessible (pagination is premium → 402)
+  - passing a large `limit` also 402s; the default page 0 returns the ~100 most
+    recent disclosures, which spans several days
+So each run is exactly 2 API calls (house + senate); a stable dedup key avoids
+re-inserting trades already stored.
+
+Usage:
+    python3 congress_ingest.py          # ingest latest House + Senate disclosures
+
+Requires FMP_API_KEY and DATABASE_URL in the environment.
+"""
+import os
+import sys
+import json
+import logging
+import hashlib
+import urllib.request
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-7s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("congress_ingest")
+
+FMP_API_KEY = os.getenv("FMP_API_KEY")
+FMP_BASE    = "https://financialmodelingprep.com/stable"
+
+DATABASE_URL = (os.getenv("DATABASE_URL") or "").strip()
+if DATABASE_URL.startswith("postgres://") and not DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True) if DATABASE_URL else None
+
+CONGRESS_TRADES_DDL = """
+CREATE TABLE IF NOT EXISTS congress_trades (
+    id              SERIAL PRIMARY KEY,
+    dedup_key       TEXT UNIQUE,
+    chamber         TEXT,
+    member          TEXT,
+    ticker          TEXT,
+    asset_type      TEXT,
+    txn_type        TEXT,
+    direction       TEXT,            -- 'Up' (purchase) | 'Down' (sale)
+    txn_date        TEXT,            -- transaction date  (YYYY-MM-DD)
+    disclosure_date TEXT,            -- when it was filed  (YYYY-MM-DD)
+    amount          TEXT,
+    owner           TEXT,
+    ingested_at     TIMESTAMPTZ DEFAULT NOW(),
+    processed       BOOLEAN DEFAULT FALSE
+);
+"""
+
+
+def _fetch(feed: str) -> list[dict]:
+    """Fetch page 0 of an FMP *-latest feed. Returns a list of disclosure dicts."""
+    url = f"{FMP_BASE}/{feed}?page=0&apikey={FMP_API_KEY}"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.load(r)
+
+
+def _direction(txn_type: str) -> str | None:
+    """Map an FMP transaction type to a trade direction. Skips exchanges/other."""
+    t = (txn_type or "").lower()
+    if "purchase" in t:
+        return "Up"
+    if "sale" in t:
+        return "Down"
+    return None
+
+
+def _ticker_ok(sym: str) -> bool:
+    return bool(sym) and sym.isalpha() and 1 <= len(sym) <= 5
+
+
+def ingest() -> int:
+    if not FMP_API_KEY:
+        log.error("FMP_API_KEY not set — cannot ingest. Add it to .env / the FMP_API_KEY secret.")
+        sys.exit(1)
+    if engine is None:
+        log.error("DATABASE_URL not set.")
+        sys.exit(1)
+
+    with engine.begin() as conn:
+        conn.execute(text(CONGRESS_TRADES_DDL))
+
+    total_new = 0
+    with engine.begin() as conn:
+        for chamber, feed in (("house", "house-latest"), ("senate", "senate-latest")):
+            try:
+                records = _fetch(feed)
+            except Exception as e:
+                log.error("%s fetch failed: %s", feed, e)
+                continue
+            log.info("%s: fetched %d disclosures", chamber, len(records))
+
+            new = 0
+            for rec in records:
+                sym        = (rec.get("symbol") or "").strip().upper()
+                asset_type = rec.get("assetType") or ""
+                txn_type   = rec.get("type") or ""
+                direction  = _direction(txn_type)
+
+                # Quality filter: a real equity ticker, an equity asset, and a
+                # clear buy/sell direction. Drops bonds, funds, and exchanges.
+                if not _ticker_ok(sym) or direction is None or "stock" not in asset_type.lower():
+                    continue
+
+                member = (rec.get("office")
+                          or f"{rec.get('firstName', '')} {rec.get('lastName', '')}").strip()
+                disc   = rec.get("disclosureDate") or ""
+                txn    = rec.get("transactionDate") or ""
+                amount = rec.get("amount") or ""
+                owner  = rec.get("owner") or ""
+
+                key = hashlib.sha1(
+                    "|".join([chamber, member, sym, txn_type, txn, disc, amount]).encode()
+                ).hexdigest()
+
+                res = conn.execute(
+                    text("""
+                        INSERT INTO congress_trades
+                            (dedup_key, chamber, member, ticker, asset_type, txn_type,
+                             direction, txn_date, disclosure_date, amount, owner)
+                        VALUES
+                            (:k, :ch, :m, :tk, :at, :tt, :d, :td, :dd, :am, :ow)
+                        ON CONFLICT (dedup_key) DO NOTHING
+                    """),
+                    {"k": key, "ch": chamber, "m": member, "tk": sym, "at": asset_type,
+                     "tt": txn_type, "d": direction, "td": txn, "dd": disc,
+                     "am": amount, "ow": owner},
+                )
+                if res.rowcount:
+                    new += 1
+
+            log.info("%s: %d new equity trade(s) inserted", chamber, new)
+            total_new += new
+
+    log.info("Done — %d new congressional trades ingested", total_new)
+    return total_new
+
+
+if __name__ == "__main__":
+    ingest()

--- a/discover.py
+++ b/discover.py
@@ -9,7 +9,7 @@ tightness threshold get promoted to the live trading registry.
 Safety checks built in:
   - Minimum usable tweets gate (≥ 30 post-filter) before running analysis
   - Rate-limit-safe delays between pages and between accounts
-  - Exponential backoff on tweety-ns errors
+  - Exponential backoff on Twitter fetch errors
   - Progress tracked in DB — safe to interrupt and resume
   - Deduplication — won't add the same tweet twice
 
@@ -22,8 +22,8 @@ Usage:
     python3 discover.py --reset BillAckman     # re-queue a specific handle
     python3 discover.py --promote 0.20         # re-check and promote above threshold
 
-Note: runs locally only — needs session.tw_session from tweety-ns auth.
-      Not suitable for GitHub Actions (no persistent session file).
+Note: runs locally only — needs twitter_cookies.json from twikit auth
+      (see test_twitter_cookies.py to generate it).
 """
 
 import argparse
@@ -106,6 +106,16 @@ CATEGORY_UNIVERSE = {
     ],
     "media": [
         "SPY", "QQQ", "NVDA", "AAPL", "MSFT", "TSLA",
+    ],
+    "congressional": [
+        # Broad ETF sweep — relationship_analysis will find which sectors react
+        "SPY", "QQQ", "XLF", "XLE", "XLK", "XLI", "XLB", "ITA",
+        "SOXX", "TLT", "GLD", "EEM", "SLX",
+    ],
+    "policy": [
+        # Tariffs → industrials/semis/materials; rates → bonds/gold; defense → ITA
+        "SPY", "QQQ", "XLI", "SOXX", "XLB", "SLX", "XLE", "ITA",
+        "TLT", "GLD", "XLF", "EEM",
     ],
     "default": [
         "SPY", "QQQ", "NVDA", "AAPL", "MSFT", "TSLA", "COIN", "MSTR",
@@ -685,7 +695,7 @@ async def process_candidate(handle: str, name: str, category: str,
         log.info("  @%s: no tweets returned", handle)
         update_candidate(handle, status="insufficient_data",
                          tweets_fetched=0, usable_tweets=0,
-                         error_msg="No tweets returned from tweety-ns")
+                         error_msg="No tweets returned from Twitter")
         return
 
     fetched = len(tweets_df)

--- a/model/predict.py
+++ b/model/predict.py
@@ -20,8 +20,41 @@ from pipeline_utils import shift_weekend_to_monday
 
 MODEL_PATH = os.path.join(os.path.dirname(__file__), "trained_model.pkl")
 
-_vix_cache = {}   # (start_iso, end_iso) → {date: float}
-_earnings_cache = {}  # ticker → set of "YYYY-MM-DD"
+_model = None
+_vix_cache = {}           # month_key → {date: float}
+_earnings_cache = {}      # ticker → set of "YYYY-MM-DD"
+_news_sentiment_cache = {}  # (ticker, date_iso) → float | None
+
+
+def _get_model():
+    global _model
+    if _model is None:
+        if not os.path.exists(MODEL_PATH):
+            raise FileNotFoundError(
+                f"No trained model found at {MODEL_PATH}. "
+                "Run 'python3 model/baseline.py' first to train and save it."
+            )
+        _model = joblib.load(MODEL_PATH)
+    return _model
+
+
+def _get_live_news_sentiment(ticker: str, target_date) -> float | None:
+    """Fetch Finnhub news sentiment for ticker on target_date, cached by (ticker, date)."""
+    date_iso = target_date.isoformat() if hasattr(target_date, "isoformat") else str(target_date)[:10]
+    cache_key = (ticker, date_iso)
+    if cache_key in _news_sentiment_cache:
+        return _news_sentiment_cache[cache_key]
+    try:
+        from context import _finnhub_news
+        from classifier import get_sentiment_score
+        import datetime as _dt
+        target = _dt.date.fromisoformat(date_iso)
+        articles = _finnhub_news(ticker, target - timedelta(days=1), target + timedelta(days=1), limit=10)
+        result = round(sum(get_sentiment_score(a["title"]) for a in articles) / len(articles), 4) if articles else None
+    except Exception:
+        result = None
+    _news_sentiment_cache[cache_key] = result
+    return result
 
 
 def _get_vix(target_date):
@@ -125,7 +158,7 @@ def _build_feature_row(tweet_row, stocks_df, ticker=None):
         "vix_at_tweet":         _get_vix(target_date_only),
         "days_to_earnings":     _get_days_to_earnings(ticker, target_date_only) if ticker else None,
         "prev_day_direction":   prev_day_direction,
-        "news_sentiment_score": None,  # fetched live via get_news_for_date if needed; imputer fills with median
+        "news_sentiment_score": _get_live_news_sentiment(ticker, target_date_only) if ticker else None,
         "refined_sentiment":    get_refined_sentiment(sentiment),
         "tone_category":        get_tone_category(text, sentiment),
         "tweet_type":           get_tweet_type(text),
@@ -145,13 +178,7 @@ def predict_tweets(tweets_df, stocks_df, ticker=None):
         predicted_direction  — "Up" or "Down"
         confidence_pct       — model's confidence as a percentage (e.g. 64.2)
     """
-    if not os.path.exists(MODEL_PATH):
-        raise FileNotFoundError(
-            f"No trained model found at {MODEL_PATH}. "
-            "Run 'python3 model/baseline.py' first to train and save it."
-        )
-
-    model = joblib.load(MODEL_PATH)
+    model = _get_model()
 
     feature_rows = [_build_feature_row(row, stocks_df, ticker=ticker) for _, row in tweets_df.iterrows()]
     features_df = pd.DataFrame(feature_rows)

--- a/processor.py
+++ b/processor.py
@@ -1,4 +1,6 @@
 import os
+import json
+import logging
 import asyncio
 import pandas as pd
 from datetime import datetime, timezone, timedelta
@@ -11,16 +13,54 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+log = logging.getLogger("processor")
+
 COOKIES_PATH = os.path.join(os.path.dirname(__file__), "twitter_cookies.json")
+
+
+class TwitterAuthError(RuntimeError):
+    """Raised when Twitter cookies are missing, malformed, or expired."""
+
+
+def _load_twitter_cookies(client) -> bool:
+    """
+    Load and sanity-check twitter_cookies.json. Returns True only if usable
+    cookies were loaded. Every failure path logs a clear, actionable message —
+    a silent failure here is what froze tweet ingestion for months.
+    """
+    if not os.path.exists(COOKIES_PATH):
+        log.warning(
+            "Twitter cookies not found at %s — tweet fetching is DISABLED. "
+            "Generate them with `python3 test_twitter_cookies.py <auth_token> <ct0>` "
+            "(see README: Twitter cookie setup).", COOKIES_PATH,
+        )
+        return False
+    try:
+        with open(COOKIES_PATH) as f:
+            cookies = json.load(f)
+    except Exception as e:
+        log.error("Twitter cookies at %s are not valid JSON (%s) — regenerate them.",
+                  COOKIES_PATH, e)
+        return False
+    missing = [k for k in ("auth_token", "ct0") if not cookies.get(k)]
+    if missing:
+        log.error("Twitter cookies at %s missing required keys %s — regenerate them.",
+                  COOKIES_PATH, missing)
+        return False
+    try:
+        client.load_cookies(COOKIES_PATH)
+    except Exception as e:
+        log.error("twikit failed to load cookies from %s (%s) — regenerate them.",
+                  COOKIES_PATH, e)
+        return False
+    log.info("Twitter cookies loaded from %s", COOKIES_PATH)
+    return True
+
 
 class DataProcessor:
     def __init__(self):
         self.twitter_client = TwikitClient("en-US")
-        if os.path.exists(COOKIES_PATH):
-            self.twitter_client.load_cookies(COOKIES_PATH)
-        else:
-            print(f"WARNING: Twitter cookies not found at {COOKIES_PATH}. "
-                  "Tweet fetching will fail. See README for cookie setup.")
+        self.cookies_loaded = _load_twitter_cookies(self.twitter_client)
         # Market-data client works with either live or paper keys (free IEX feed).
         # Prefer live data keys (set in the retrain workflow); fall back to paper
         # keys (set in the watcher workflow) so both environments work.
@@ -38,9 +78,24 @@ class DataProcessor:
             return 0
 
     async def get_tweets(self, username, pages=50):
+        if not self.cookies_loaded:
+            raise TwitterAuthError(
+                "Twitter cookies missing or invalid — cannot fetch tweets. "
+                "Regenerate twitter_cookies.json (see README: Twitter cookie setup)."
+            )
         all_tweets = []
-        user = await self.twitter_client.get_user_by_screen_name(username)
-        result = await self.twitter_client.get_user_tweets(user.id, tweet_type="Tweets", count=20)
+        try:
+            user = await self.twitter_client.get_user_by_screen_name(username)
+            result = await self.twitter_client.get_user_tweets(user.id, tweet_type="Tweets", count=20)
+        except Exception as e:
+            msg = str(e).lower()
+            if any(s in msg for s in ("401", "unauthorized", "forbidden",
+                                      "could not authenticate", "logged out", "denied")):
+                raise TwitterAuthError(
+                    f"Twitter auth rejected while fetching @{username} ({e}). "
+                    "Cookies are likely expired — regenerate twitter_cookies.json."
+                ) from e
+            raise
 
         for page_num in range(pages):
             for tweet in result:

--- a/processor.py
+++ b/processor.py
@@ -2,22 +2,7 @@ import os
 import asyncio
 import pandas as pd
 from datetime import datetime, timezone, timedelta
-from tweety import Twitter
-import tweety.transaction
-
-# Runtime patch to fix tweety-ns throwing "Couldn't get animation key indices" error
-original_get_indices = tweety.transaction.TransactionGenerator.get_indices
-
-def patched_get_indices(self, home_page_html=None):
-    try:
-        return original_get_indices(self, home_page_html)
-    except Exception as e:
-        if "Couldn't get animation key indices" in str(e):
-            return 0, [1, 2, 3, 4, 5]
-        raise
-
-tweety.transaction.TransactionGenerator.get_indices = patched_get_indices
-
+from twikit import Client as TwikitClient
 from classifier import get_sentiment_score, get_finbert_scores_batch
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
@@ -26,12 +11,22 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+COOKIES_PATH = os.path.join(os.path.dirname(__file__), "twitter_cookies.json")
+
 class DataProcessor:
     def __init__(self):
-        self.twitter_client = Twitter("session")
+        self.twitter_client = TwikitClient("en-US")
+        if os.path.exists(COOKIES_PATH):
+            self.twitter_client.load_cookies(COOKIES_PATH)
+        else:
+            print(f"WARNING: Twitter cookies not found at {COOKIES_PATH}. "
+                  "Tweet fetching will fail. See README for cookie setup.")
+        # Market-data client works with either live or paper keys (free IEX feed).
+        # Prefer live data keys (set in the retrain workflow); fall back to paper
+        # keys (set in the watcher workflow) so both environments work.
         self.stock_client = StockHistoricalDataClient(
-            os.getenv("ALPACA_API_KEY"),
-            os.getenv("ALPACA_SECRET_KEY")
+            os.getenv("ALPACA_API_KEY") or os.getenv("ALPACA_PAPER_API_KEY"),
+            os.getenv("ALPACA_SECRET_KEY") or os.getenv("ALPACA_PAPER_SECRET_KEY"),
         )
 
     @staticmethod
@@ -44,30 +39,42 @@ class DataProcessor:
 
     async def get_tweets(self, username, pages=50):
         all_tweets = []
-        user_tweets = await self.twitter_client.get_tweets(username, pages=pages)
-        for tweet in user_tweets:
-            # Skip retweets — they reflect someone else's words, not the CEO's
-            if tweet.is_retweet:
-                continue
+        user = await self.twitter_client.get_user_by_screen_name(username)
+        result = await self.twitter_client.get_user_tweets(user.id, tweet_type="Tweets", count=20)
 
-            created = tweet.created_on
-            tweet_hour = created.hour if hasattr(created, 'hour') else 0
-            tweet_minute = created.minute if hasattr(created, 'minute') else 0
-            # NYSE opens 9:30 ET = 14:30 UTC, closes 16:00 ET = 21:00 UTC
-            is_premarket = tweet_hour < 14 or (tweet_hour == 14 and tweet_minute < 30)
+        for page_num in range(pages):
+            for tweet in result:
+                # Skip retweets — they reflect someone else's words, not the CEO's
+                if tweet.retweeted_tweet is not None:
+                    continue
 
-            all_tweets.append({
-                'ceo': username,
-                'text': tweet.text,
-                'sentiment': get_sentiment_score(tweet.text),
-                'date': created,
-                'likes': self._safe_int(tweet.likes),
-                'retweet_count': self._safe_int(tweet.retweet_counts),
-                'view_count': self._safe_int(tweet.views),
-                'reply_count': self._safe_int(tweet.reply_counts),
-                'tweet_hour': tweet_hour,
-                'is_premarket': is_premarket,
-            })
+                created = tweet.created_at_datetime
+                if created and created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                tweet_hour = created.hour if created else 0
+                tweet_minute = created.minute if created else 0
+                # NYSE opens 9:30 ET = 14:30 UTC, closes 16:00 ET = 21:00 UTC
+                is_premarket = tweet_hour < 14 or (tweet_hour == 14 and tweet_minute < 30)
+
+                all_tweets.append({
+                    'ceo': username,
+                    'text': tweet.full_text or tweet.text,
+                    'sentiment': get_sentiment_score(tweet.full_text or tweet.text),
+                    'date': created,
+                    'likes': self._safe_int(tweet.favorite_count),
+                    'retweet_count': self._safe_int(tweet.retweet_count),
+                    'view_count': self._safe_int(tweet.view_count),
+                    'reply_count': self._safe_int(tweet.reply_count),
+                    'tweet_hour': tweet_hour,
+                    'is_premarket': is_premarket,
+                })
+
+            if page_num < pages - 1:
+                try:
+                    result = await result.next()
+                except Exception:
+                    break  # no more pages
+
         df = pd.DataFrame(all_tweets)
         if not df.empty:
             df['finbert_score'] = get_finbert_scores_batch(df['text'].tolist())

--- a/requirements-watcher.txt
+++ b/requirements-watcher.txt
@@ -12,5 +12,5 @@ requests
 pytz
 tzdata
 scipy
-tweety-ns
+twikit==2.3.3
 textblob

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ psycopg2-binary
 pydantic==2.12.5
 python-dotenv==1.2.2
 pandas==2.3.3
-tweety-ns
+twikit==2.3.3
 vaderSentiment==3.3.2
 alpaca-py
 streamlit==1.55.0

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -260,6 +260,18 @@ async def run():
         for s in skipped:
             print(f"  skipped {s['username']}: {s['reason']}")
 
+        # Fail loudly if nothing came in and every account errored — this is the
+        # signature of broken Twitter auth (expired/missing cookies), which
+        # otherwise silently freezes ingestion. Exit non-zero so CI goes red.
+        if total_records == 0 and skipped:
+            print(
+                "\nERROR: 0 records ingested and all fetches failed — Twitter auth is "
+                "likely broken. Regenerate twitter_cookies.json / the TWITTER_COOKIES "
+                "secret (see README: Twitter cookie setup).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     except Exception as exc:
         db.rollback()
         print(f"\nFATAL: {exc}", file=sys.stderr)

--- a/targets.py
+++ b/targets.py
@@ -30,6 +30,14 @@ CEO_TARGETS = {
     "george_kurtz":    {"name": "George Kurtz",        "ticker": "CRWD"},
     "eldsjal":         {"name": "Daniel Ek",           "ticker": "SPOT"},
     "RJScaringe":      {"name": "RJ Scaringe",         "ticker": "RIVN"},
+    # Congressional trade aggregators — default to SPY until registry finds tighter fits.
+    # (quiver_quant omitted — account is suspended on X; see candidates.csv)
+    "unusual_whales":  {"name": "Unusual Whales",       "ticker": "SPY"},
+    "capitoltrades":   {"name": "Capitol Trades",       "ticker": "SPY"},
+    # Policy accounts — default to broad market until registry calibrates sector ETFs
+    "realDonaldTrump": {"name": "Donald Trump",         "ticker": "SPY"},
+    "POTUS":           {"name": "POTUS",                "ticker": "SPY"},
+    "ScottBessent":    {"name": "Scott Bessent",        "ticker": "TLT"},
 }
 
 # Flat handle → ticker dict for pipeline loops

--- a/test_twitter_cookies.py
+++ b/test_twitter_cookies.py
@@ -1,0 +1,42 @@
+"""
+One-shot test to validate Twitter cookies.
+
+Usage:
+    python test_twitter_cookies.py <auth_token> <ct0>
+
+Example:
+    python test_twitter_cookies.py abc123... def456...
+
+This writes twitter_cookies.json and fetches 2 tweets from @elonmusk to confirm auth works.
+"""
+import asyncio, json, sys, os
+from twikit import Client
+
+COOKIES_PATH = os.path.join(os.path.dirname(__file__), "twitter_cookies.json")
+
+async def main(auth_token: str, ct0: str):
+    cookies = {"auth_token": auth_token, "ct0": ct0}
+    with open(COOKIES_PATH, "w") as f:
+        json.dump(cookies, f)
+    print(f"Wrote {COOKIES_PATH}")
+
+    client = Client("en-US")
+    client.load_cookies(COOKIES_PATH)
+
+    print("Fetching @elonmusk profile...")
+    user = await client.get_user_by_screen_name("elonmusk")
+    print(f"  User: {user.name} (@{user.screen_name}), followers: {user.followers_count:,}")
+
+    print("Fetching recent tweets...")
+    tweets = await client.get_user_tweets(user.id, tweet_type="Tweets", count=5)
+    for i, t in enumerate(tweets, 1):
+        ts = t.created_at_datetime
+        print(f"  [{i}] {str(ts)[:16]} — {(t.full_text or t.text)[:80]}")
+
+    print("\nCookies are valid! twitter_cookies.json is ready.")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python test_twitter_cookies.py <auth_token> <ct0>")
+        sys.exit(1)
+    asyncio.run(main(sys.argv[1], sys.argv[2]))

--- a/watch.py
+++ b/watch.py
@@ -127,10 +127,24 @@ CREATE TABLE IF NOT EXISTS signal_queue (
 """
 
 
+_MANAGED_POSITIONS_DDL = """
+CREATE TABLE IF NOT EXISTS managed_positions (
+    ticker            TEXT PRIMARY KEY,
+    side              TEXT,            -- 'long' or 'short'
+    ceo               TEXT,
+    topic             TEXT,
+    opened_at         TIMESTAMPTZ DEFAULT NOW(),
+    exit_after        TIMESTAMPTZ,    -- close at/after this time (next-day horizon)
+    entry_confidence  FLOAT
+);
+"""
+
+
 def init_db():
     with engine.connect() as conn:
         conn.execute(text(_WATCHER_STATE_DDL))
         conn.execute(text(_SIGNAL_QUEUE_DDL))
+        conn.execute(text(_MANAGED_POSITIONS_DDL))
         conn.commit()
 
 
@@ -276,6 +290,20 @@ def next_market_open(now_et: datetime) -> datetime:
     return candidate
 
 
+def next_day_exit_time(entry_et: datetime) -> datetime:
+    """
+    Exit horizon for a trade: the next trading day after entry, at 15:30 ET.
+
+    The model predicts next-day direction, so positions are held until the close
+    of the following session. 15:30 (not 16:00) ensures the last pre-close poll
+    cycle catches the exit while the market is still open.
+    """
+    d = entry_et + timedelta(days=1)
+    while d.weekday() >= 5 or d.strftime("%Y-%m-%d") in _NYSE_HOLIDAYS:
+        d += timedelta(days=1)
+    return d.replace(hour=15, minute=30, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Signal gates
 # ---------------------------------------------------------------------------
@@ -301,7 +329,7 @@ def passes_gates(row: pd.Series, eng_threshold: float, ceo: str | None = None) -
     # was tuned for opinionated CEO tweets and would wrongly discard them, so exempt
     # those topics — the ticker/direction comes from the post itself, not sentiment.
     topic = get_tweet_topic(text, ceo) if ceo else None
-    if topic not in ("congressional_trade", "policy"):
+    if topic not in ("congressional_trade", "policy", "short_report"):
         finbert = row.get("finbert_score")
         if finbert is not None:
             if abs(float(finbert)) < FINBERT_THRESHOLD:
@@ -320,22 +348,25 @@ def passes_gates(row: pd.Series, eng_threshold: float, ceo: str | None = None) -
 # Trade placement (shared by immediate + queued paths)
 # ---------------------------------------------------------------------------
 
-def place_order(ticker: str, direction: str, dry_run: bool) -> str | None:
-    """Place a paper market order. Returns Alpaca order ID or None on dry-run."""
+def _trading_client():
+    """Construct an Alpaca paper TradingClient from env credentials."""
     from alpaca.trading.client import TradingClient
-    from alpaca.trading.requests import MarketOrderRequest
-    from alpaca.trading.enums import OrderSide, TimeInForce
-    from pipeline_utils import compute_technicals
-    from processor import DataProcessor
-
-    if dry_run:
-        return None
-
-    tc   = TradingClient(
+    return TradingClient(
         os.getenv("ALPACA_PAPER_API_KEY"),
         os.getenv("ALPACA_PAPER_SECRET_KEY"),
         paper=True,
     )
+
+
+def place_order(ticker: str, direction: str, dry_run: bool) -> str | None:
+    """Place a paper market order. Returns Alpaca order ID or None on dry-run."""
+    from alpaca.trading.requests import MarketOrderRequest
+    from alpaca.trading.enums import OrderSide, TimeInForce
+
+    if dry_run:
+        return None
+
+    tc   = _trading_client()
     side = OrderSide.BUY if direction == "Up" else OrderSide.SELL
 
     # Position management
@@ -411,6 +442,83 @@ def log_trade(db, ceo: str, tweet_text: str, tweet_date, topic: str,
 
 
 # ---------------------------------------------------------------------------
+# Position lifecycle — scheduled exit at the next-day prediction horizon
+# ---------------------------------------------------------------------------
+
+def register_position(db, ticker: str, side: str, ceo: str, topic: str,
+                      confidence: float, exit_after: datetime):
+    """Record (or refresh) an open position so it can be closed at its horizon."""
+    db.execute(
+        text("""
+            INSERT INTO managed_positions
+                (ticker, side, ceo, topic, opened_at, exit_after, entry_confidence)
+            VALUES (:ticker, :side, :ceo, :topic, NOW(), :exit_after, :conf)
+            ON CONFLICT (ticker) DO UPDATE SET
+                side             = EXCLUDED.side,
+                ceo              = EXCLUDED.ceo,
+                topic            = EXCLUDED.topic,
+                opened_at        = NOW(),
+                exit_after       = EXCLUDED.exit_after,
+                entry_confidence = EXCLUDED.entry_confidence
+        """),
+        {"ticker": ticker, "side": side, "ceo": ceo, "topic": topic,
+         "exit_after": exit_after, "conf": confidence},
+    )
+
+
+def close_due_positions(dry_run: bool):
+    """
+    Close any tracked position whose next-day exit horizon has passed.
+    Runs only during market hours (a market order needs an open market).
+    """
+    now_et = datetime.now(ET)
+    if market_status(now_et) != "open":
+        return
+
+    db = Session()
+    try:
+        rows = db.execute(
+            text("""
+                SELECT ticker, side, ceo, topic FROM managed_positions
+                WHERE exit_after <= NOW()
+            """)
+        ).fetchall()
+        if not rows:
+            return
+
+        tc = None if dry_run else _trading_client()
+        for r in rows:
+            ticker = r.ticker
+            exit_side = "sell" if r.side == "long" else "buy_to_cover"
+            try:
+                if not dry_run:
+                    tc.close_position(ticker)
+                log.info(
+                    "%sEXIT %s (%s/%s) — closed at next-day horizon",
+                    "[DRY-RUN] " if dry_run else "", ticker, r.ceo, r.topic,
+                )
+                log_trade(db, r.ceo, "", None, r.topic, ticker,
+                          "exit", 0.0, None, 0.0, None,
+                          "exit" if not dry_run else "dry-run-exit", exit_side,
+                          skip_reason="scheduled next-day horizon exit")
+                db.execute(text("DELETE FROM managed_positions WHERE ticker = :t"),
+                           {"t": ticker})
+            except Exception as e:
+                msg = str(e).lower()
+                log.error("  Exit failed for %s: %s", ticker, e)
+                # Position already gone at the broker — stop tracking it.
+                if "position does not exist" in msg or "not found" in msg or "404" in msg:
+                    db.execute(text("DELETE FROM managed_positions WHERE ticker = :t"),
+                               {"t": ticker})
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        log.error("Exit sweep error: %s", e)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # Signal evaluation pipeline for a single tweet row
 # ---------------------------------------------------------------------------
 
@@ -459,6 +567,27 @@ def evaluate_tweet(row: pd.Series, ceo: str, db,
             "tightness":  1.0,
             "direction":  trade["direction"],
             "confidence": 80.0,
+            "sentiment":  sentiment,
+            "finbert":    float(finbert) if finbert is not None else None,
+        }
+
+    # Fast path — short-seller report: a published report is a strong DOWN signal
+    # on the named ticker. Skip registry and ML; the ticker comes from the post.
+    if topic == "short_report":
+        from classifier import parse_short_seller_report
+        rep = parse_short_seller_report(tweet_text)
+        if rep is None:
+            return None
+        log.info("  SHORT REPORT: %s → %s (Down)", ceo, rep["ticker"])
+        return {
+            "ceo":        ceo,
+            "tweet_text": tweet_text,
+            "tweet_date": tweet_date,
+            "topic":      topic,
+            "ticker":     rep["ticker"],
+            "tightness":  1.0,
+            "direction":  "Down",
+            "confidence": 75.0,
             "sentiment":  sentiment,
             "finbert":    float(finbert) if finbert is not None else None,
         }
@@ -578,6 +707,27 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
     side_str   = "buy" if direction == "Up" else "sell_short"
     prefix     = "[DRY-RUN] " if dry_run else ""
 
+    # Idempotency — never trade the same tweet twice. Guards against retries and
+    # against two watcher deployments (the Render worker and the GitHub Actions
+    # db-only run) both processing the same signal.
+    if not dry_run and tweet_date is not None:
+        td_str = str(tweet_date)[:19]
+        dup = db.execute(
+            text("""
+                SELECT 1 FROM paper_trades
+                WHERE ceo = :ceo AND ticker = :ticker AND tweet_date = :td
+                  AND status = 'placed'
+                LIMIT 1
+            """),
+            {"ceo": ceo, "ticker": ticker, "td": td_str},
+        ).fetchone()
+        if dup:
+            log.info("  %s %s/%s already traded for this tweet — skipping duplicate",
+                     ceo, topic, ticker)
+            if "id" in sig:
+                mark_signal_processed(db, sig["id"], None)
+            return
+
     try:
         order_id = place_order(ticker, direction, dry_run)
 
@@ -604,6 +754,13 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
                       order_id, "placed" if not dry_run else "dry-run", side_str)
             if not dry_run:
                 increment_trades(db, ceo)
+                # Track the open position so it's closed at the next-day horizon
+                register_position(
+                    db, ticker,
+                    "long" if direction == "Up" else "short",
+                    ceo, topic, confidence,
+                    next_day_exit_time(datetime.now(ET)),
+                )
 
         # Mark queue entry processed if it came from the queue
         if "id" in sig:
@@ -936,6 +1093,9 @@ async def run(ceo_list: list[str], dry_run: bool, interval_override: int | None,
                 poll_from_db(poll_list, dry_run)
             else:
                 await poll_once(poll_list, dry_run)
+
+        # Close any positions that have reached their next-day exit horizon
+        close_due_positions(dry_run)
 
         if once:
             break

--- a/watch.py
+++ b/watch.py
@@ -69,10 +69,22 @@ HIGH_PRIORITY_HANDLES = {
 
 CONFIDENCE_THRESHOLD = 55.0
 TIGHTNESS_THRESHOLD  = 0.20
-TRADE_NOTIONAL       = 1000.0
 TWEET_PAGES          = 2          # pages of tweets to fetch per CEO per cycle (~40 tweets)
 FINBERT_THRESHOLD    = 0.10
 MIN_TEXT_LEN         = 15
+
+# ── Position sizing (conviction-scaled) ────────────────────────────────────
+# Notional scales between MIN and MAX by a conviction score built from the
+# model confidence and the relationship tightness. TRADE_NOTIONAL is the
+# fallback/base used for logging defaults and non-signal paths.
+TRADE_NOTIONAL = float(os.getenv("TRADE_NOTIONAL", "1000"))
+MIN_NOTIONAL   = float(os.getenv("MIN_NOTIONAL",   "500"))
+MAX_NOTIONAL   = float(os.getenv("MAX_NOTIONAL",   "2500"))
+CONF_SIZING_CEILING = 90.0   # confidence at/above which the confidence factor maxes out
+
+# ── Portfolio risk caps ────────────────────────────────────────────────────
+MAX_OPEN_POSITIONS = int(os.getenv("MAX_OPEN_POSITIONS", "15"))
+MAX_DAILY_LOSS     = float(os.getenv("MAX_DAILY_LOSS", "1500"))  # halt new entries past this loss
 
 ET = ZoneInfo("America/New_York")
 
@@ -358,7 +370,56 @@ def _trading_client():
     )
 
 
-def place_order(ticker: str, direction: str, dry_run: bool) -> str | None:
+def position_notional(confidence: float, tightness: float | None) -> float:
+    """
+    Conviction-scaled trade size. Blends model confidence and relationship
+    tightness into a 0–1 conviction score, then maps it onto [MIN, MAX] notional.
+
+    Confidence contributes from the gate (55%) up to CONF_SIZING_CEILING (90%);
+    tightness contributes directly (None → 0.5, the neutral mid-point used by
+    fast-path signals that skip the registry).
+    """
+    span = max(CONF_SIZING_CEILING - CONFIDENCE_THRESHOLD, 1.0)
+    conf_frac = max(0.0, min((confidence - CONFIDENCE_THRESHOLD) / span, 1.0))
+    tight = tightness if tightness is not None else 0.5
+    conviction = 0.6 * conf_frac + 0.4 * tight
+    return round(MIN_NOTIONAL + conviction * (MAX_NOTIONAL - MIN_NOTIONAL), 2)
+
+
+def risk_gate(db, ticker: str, dry_run: bool) -> tuple[bool, str]:
+    """
+    Portfolio-level guardrails checked before opening a new position.
+    Returns (allowed, reason). Exits and same-ticker reversals are not gated
+    here — they don't add a new position slot.
+    """
+    already_tracked = db.execute(
+        text("SELECT 1 FROM managed_positions WHERE ticker = :t"), {"t": ticker}
+    ).fetchone()
+
+    if not already_tracked:
+        open_count = db.execute(
+            text("SELECT COUNT(*) FROM managed_positions")
+        ).scalar() or 0
+        if open_count >= MAX_OPEN_POSITIONS:
+            return False, f"max open positions reached ({open_count}/{MAX_OPEN_POSITIONS})"
+
+    if dry_run:
+        return True, ""
+
+    # Daily-loss kill switch — Alpaca tracks equity vs the prior close.
+    try:
+        acct = _trading_client().get_account()
+        daily_pl = float(acct.equity) - float(acct.last_equity)
+        if daily_pl <= -MAX_DAILY_LOSS:
+            return False, f"daily loss limit hit (P&L ${daily_pl:,.0f})"
+    except Exception as e:
+        log.warning("  risk check: could not read account (%s) — allowing trade", e)
+
+    return True, ""
+
+
+def place_order(ticker: str, direction: str, notional: float,
+                dry_run: bool) -> str | None:
     """Place a paper market order. Returns Alpaca order ID or None on dry-run."""
     from alpaca.trading.requests import MarketOrderRequest
     from alpaca.trading.enums import OrderSide, TimeInForce
@@ -382,7 +443,7 @@ def place_order(ticker: str, direction: str, dry_run: bool) -> str | None:
 
     if side == OrderSide.BUY:
         order_req = MarketOrderRequest(
-            symbol=ticker, notional=TRADE_NOTIONAL,
+            symbol=ticker, notional=notional,
             side=side, time_in_force=TimeInForce.DAY,
         )
     else:
@@ -398,7 +459,7 @@ def place_order(ticker: str, direction: str, dry_run: bool) -> str | None:
         except Exception:
             price = 100.0
         order_req = MarketOrderRequest(
-            symbol=ticker, qty=max(1, int(TRADE_NOTIONAL / price)),
+            symbol=ticker, qty=max(1, int(notional / price)),
             side=side, time_in_force=TimeInForce.DAY,
         )
 
@@ -410,7 +471,8 @@ def log_trade(db, ceo: str, tweet_text: str, tweet_date, topic: str,
               ticker: str, direction: str, confidence: float,
               tightness: float | None, sentiment: float,
               order_id: str | None, status: str,
-              side_str: str, skip_reason: str | None = None):
+              side_str: str, skip_reason: str | None = None,
+              notional: float = TRADE_NOTIONAL):
     db.execute(
         text("""
             INSERT INTO paper_trades
@@ -429,7 +491,7 @@ def log_trade(db, ceo: str, tweet_text: str, tweet_date, topic: str,
             "topic":      topic,
             "ticker":     ticker,
             "side":       side_str,
-            "notional":   TRADE_NOTIONAL,
+            "notional":   notional,
             "direction":  direction,
             "conf":       confidence,
             "sent":       sentiment,
@@ -728,8 +790,23 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
                 mark_signal_processed(db, sig["id"], None)
             return
 
+    # Portfolio risk caps — block new entries past position/loss limits.
+    allowed, reason = risk_gate(db, ticker, dry_run)
+    if not allowed:
+        log.warning("  RISK HALT — %s %s/%s skipped: %s", ceo, topic, ticker, reason)
+        log_trade(db, ceo, tweet_text, tweet_date, topic, ticker,
+                  direction, confidence, tightness, sentiment,
+                  None, "skipped", side_str, skip_reason=f"risk: {reason}",
+                  notional=0.0)
+        if "id" in sig:
+            mark_signal_processed(db, sig["id"], None)
+        return
+
+    # Conviction-scaled position size
+    notional = position_notional(confidence, tightness)
+
     try:
-        order_id = place_order(ticker, direction, dry_run)
+        order_id = place_order(ticker, direction, notional, dry_run)
 
         if order_id == "DUPLICATE":
             log.info(
@@ -740,18 +817,19 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
             log_trade(db, ceo, tweet_text, tweet_date, topic, ticker,
                       direction, confidence, tightness, sentiment,
                       None, "skipped", side_str,
-                      skip_reason="already positioned same side")
+                      skip_reason="already positioned same side", notional=0.0)
         else:
             log.info(
-                "%s%s %s → %s (%s) conf=%.1f%% tight=%s — ORDER %s%s",
+                "%s%s %s → %s (%s) conf=%.1f%% tight=%s size=$%.0f — ORDER %s%s",
                 prefix, ceo, topic, ticker, direction, confidence,
-                f"{tightness:.3f}" if tightness else "n/a",
+                f"{tightness:.3f}" if tightness else "n/a", notional,
                 "PLACED" if not dry_run else "WOULD PLACE",
                 f" id={order_id}" if order_id else "",
             )
             log_trade(db, ceo, tweet_text, tweet_date, topic, ticker,
                       direction, confidence, tightness, sentiment,
-                      order_id, "placed" if not dry_run else "dry-run", side_str)
+                      order_id, "placed" if not dry_run else "dry-run", side_str,
+                      notional=notional)
             if not dry_run:
                 increment_trades(db, ceo)
                 # Track the open position so it's closed at the next-day horizon
@@ -770,7 +848,7 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
         log.error("  Order failed for %s/%s: %s", ceo, ticker, e)
         log_trade(db, ceo, tweet_text, tweet_date, topic, ticker,
                   direction, confidence, tightness, sentiment,
-                  None, "error", side_str, skip_reason=str(e))
+                  None, "error", side_str, skip_reason=str(e), notional=notional)
         # Always retire the queue entry on failure — don't retry indefinitely
         if "id" in sig:
             mark_signal_processed(db, sig["id"], None)

--- a/watch.py
+++ b/watch.py
@@ -8,7 +8,7 @@ immediately when a valid signal is detected.
 
 Flow (runs every POLL_INTERVAL seconds):
   For each CEO in the registry:
-    1. Fetch recent tweets via tweety-ns
+    1. Fetch recent tweets via twikit
     2. Identify tweets newer than last processed (dedup by date)
     3. Apply signal gates: engagement · FinBERT content · text length
     4. Classify tweet topic
@@ -48,9 +48,24 @@ load_dotenv()
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
-POLL_MARKET_HOURS_S  = 20 * 60   # 20 min during market hours
+POLL_MARKET_HOURS_S  = 20 * 60   # 20 min — full sweep of all accounts
+POLL_HIGH_PRIORITY_S =  3 * 60   # 3 min — fast lane for time-sensitive accounts
 POLL_EXTENDED_S      = 60 * 60   # 60 min pre/post market
 POLL_OVERNIGHT_S     = 4  * 60 * 60  # 4 hours overnight
+
+# Accounts polled every 3 min during market hours.
+# Short sellers publish rarely but move stocks 20-50% within minutes of posting.
+# Congressional aggregators and presidential accounts also move fast.
+HIGH_PRIORITY_HANDLES = {
+    # Short sellers — reports cause immediate, large moves
+    "HindenburgRes", "muddywaters", "CitronResearch", "GothamResearch", "PrestigeEconom1",
+    # Congressional trade aggregators — disclosures post continuously during market hours
+    "unusual_whales", "capitoltrades",
+    # Presidential / treasury — tariff tweets move sectors within minutes
+    "realDonaldTrump", "POTUS", "ScottBessent",
+    # Highest-signal CEO (tightness 0.57, 4.8% avg move)
+    "george_kurtz",
+}
 
 CONFIDENCE_THRESHOLD = 55.0
 TIGHTNESS_THRESHOLD  = 0.20
@@ -167,6 +182,17 @@ def increment_trades(db, ceo: str):
 
 
 def enqueue_signal(db, signal: dict):
+    existing = db.execute(
+        text("""
+            SELECT id FROM signal_queue
+            WHERE ceo = :ceo AND tweet_date = :tweet_date AND ticker = :ticker
+              AND processed = FALSE
+        """),
+        {"ceo": signal["ceo"], "tweet_date": signal["tweet_date"], "ticker": signal["ticker"]},
+    ).fetchone()
+    if existing:
+        log.debug("  signal already queued for %s/%s — skipping duplicate enqueue", signal["ceo"], signal["ticker"])
+        return
     db.execute(
         text("""
             INSERT INTO signal_queue
@@ -262,19 +288,29 @@ def _engagement_score(row: pd.Series) -> float:
     return likes + 2 * retweets + replies + 0.05 * views
 
 
-def passes_gates(row: pd.Series, eng_threshold: float) -> bool:
+def passes_gates(row: pd.Series, eng_threshold: float, ceo: str | None = None) -> bool:
+    from classifier import get_tweet_topic
+
     text = str(row.get("text") or row.get("tweet_text") or "")
     stripped = text.lower().replace("https://", "").replace("http://", "").strip()
     if len(stripped) < MIN_TEXT_LEN:
         return False
-    finbert = row.get("finbert_score")
-    if finbert is not None:
-        if abs(float(finbert)) < FINBERT_THRESHOLD:
-            return False
-    else:
-        # No FinBERT score available — fall back to VADER magnitude
-        if abs(float(row.get("sentiment") or row.get("sentiment_score") or 0)) < 0.15:
-            return False
+
+    # Congressional disclosures and policy statements are factual and low-sentiment
+    # by nature (e.g. "Rep. Pelosi purchased $1M-$5M of $NVDA"). The sentiment gate
+    # was tuned for opinionated CEO tweets and would wrongly discard them, so exempt
+    # those topics — the ticker/direction comes from the post itself, not sentiment.
+    topic = get_tweet_topic(text, ceo) if ceo else None
+    if topic not in ("congressional_trade", "policy"):
+        finbert = row.get("finbert_score")
+        if finbert is not None:
+            if abs(float(finbert)) < FINBERT_THRESHOLD:
+                return False
+        else:
+            # No FinBERT score available — fall back to VADER magnitude
+            if abs(float(row.get("sentiment") or row.get("sentiment_score") or 0)) < 0.15:
+                return False
+
     if _engagement_score(row) < eng_threshold:
         return False
     return True
@@ -378,16 +414,24 @@ def log_trade(db, ceo: str, tweet_text: str, tweet_date, topic: str,
 # Signal evaluation pipeline for a single tweet row
 # ---------------------------------------------------------------------------
 
-def evaluate_tweet(row: pd.Series, ceo: str, db) -> dict | None:
+def evaluate_tweet(row: pd.Series, ceo: str, db,
+                   proc=None, stocks_cache: dict | None = None) -> dict | None:
     """
     Run the full signal pipeline on one tweet.
     Returns a signal dict if the tweet passes all gates, else None.
+
+    proc         — shared DataProcessor instance (created once per poll cycle)
+    stocks_cache — dict keyed by ticker; avoids re-fetching the same 60-day
+                   window for multiple tweets mapped to the same stock
     """
     from classifier import get_tweet_topic
     from pipeline_utils import compute_technicals
     from model.predict import predict_tweets
     from targets import HANDLE_TO_TICKER
     from processor import DataProcessor
+
+    if stocks_cache is None:
+        stocks_cache = {}
 
     tweet_text = str(row.get("text") or "")
     sentiment  = float(row.get("sentiment") or 0)
@@ -397,6 +441,27 @@ def evaluate_tweet(row: pd.Series, ceo: str, db) -> dict | None:
     topic = get_tweet_topic(tweet_text, ceo)
     if topic == "personal":
         return None
+
+    # Fast path — congressional trade disclosures: skip registry and ML entirely.
+    # The ticker and direction are explicit in the post; confidence is fixed at 80%.
+    if topic == "congressional_trade":
+        from classifier import parse_congressional_trade
+        trade = parse_congressional_trade(tweet_text)
+        if trade is None:
+            return None
+        log.info("  CONGRESSIONAL TRADE: %s → %s (%s)", ceo, trade["ticker"], trade["direction"])
+        return {
+            "ceo":        ceo,
+            "tweet_text": tweet_text,
+            "tweet_date": tweet_date,
+            "topic":      topic,
+            "ticker":     trade["ticker"],
+            "tightness":  1.0,
+            "direction":  trade["direction"],
+            "confidence": 80.0,
+            "sentiment":  sentiment,
+            "finbert":    float(finbert) if finbert is not None else None,
+        }
 
     # Registry lookup
     rel = db.execute(
@@ -415,20 +480,21 @@ def evaluate_tweet(row: pd.Series, ceo: str, db) -> dict | None:
     if not ticker:
         return None
 
-    # ML prediction — fetch technicals, fall back to empty DF if data API is
-    # unavailable (e.g. GitHub Actions). Model imputes RSI/ATR with training medians.
-    end_dt   = datetime.now(timezone.utc)
-    start_dt = end_dt - timedelta(days=60)
-    try:
-        proc      = DataProcessor()
-        stocks_df = proc.get_stocks(ticker, start_date=start_dt, end_date=end_dt)
-        stocks_df = compute_technicals(stocks_df)
-    except Exception as _stock_err:
-        log.debug("  Stock data unavailable for %s (%s) — using empty DF", ticker, _stock_err)
-        stocks_df = pd.DataFrame(
-            columns=["date_only", "close", "open", "high", "low",
-                     "volume", "rsi_14", "atr_14"]
-        )
+    # Fetch technicals once per ticker per cycle, reuse across tweets
+    if ticker not in stocks_cache:
+        end_dt   = datetime.now(timezone.utc) - timedelta(days=1)
+        start_dt = end_dt - timedelta(days=60)
+        try:
+            _proc = proc if proc is not None else DataProcessor()
+            df = _proc.get_stocks(ticker, start_date=start_dt, end_date=end_dt)
+            stocks_cache[ticker] = compute_technicals(df)
+        except Exception as _stock_err:
+            log.debug("  Stock data unavailable for %s (%s) — using empty DF", ticker, _stock_err)
+            stocks_cache[ticker] = pd.DataFrame(
+                columns=["date_only", "close", "open", "high", "low",
+                         "volume", "rsi_14", "atr_14"]
+            )
+    stocks_df = stocks_cache[ticker]
 
     dt = pd.to_datetime(tweet_date)
     if dt.tzinfo is None:
@@ -548,6 +614,9 @@ def _execute_signal(sig: dict, db, dry_run: bool, source: str = "live"):
         log_trade(db, ceo, tweet_text, tweet_date, topic, ticker,
                   direction, confidence, tightness, sentiment,
                   None, "error", side_str, skip_reason=str(e))
+        # Always retire the queue entry on failure — don't retry indefinitely
+        if "id" in sig:
+            mark_signal_processed(db, sig["id"], None)
 
 
 # ---------------------------------------------------------------------------
@@ -562,13 +631,16 @@ def poll_from_db(ceo_list: list[str], dry_run: bool):
     (e.g. GitHub Actions).
 
     DB rows already have finbert_score, sentiment_score, engagement columns —
-    no transformers or tweety-ns required.
+    no transformers or twikit required.
     """
     now_et = datetime.now(ET)
     status = market_status(now_et)
     db     = Session()
 
     try:
+        from processor import DataProcessor
+        proc         = DataProcessor()
+        stocks_cache = {}
         new_signal_count = 0
 
         for ceo in ceo_list:
@@ -636,10 +708,10 @@ def poll_from_db(ceo_list: list[str], dry_run: bool):
                 ) if not all_eng_df.empty else 0.0
 
                 for _, row in new_df.iterrows():
-                    if not passes_gates(row, eng_threshold):
+                    if not passes_gates(row, eng_threshold, ceo):
                         continue
 
-                    signal = evaluate_tweet(row, ceo, db)
+                    signal = evaluate_tweet(row, ceo, db, proc=proc, stocks_cache=stocks_cache)
                     if signal is None:
                         continue
 
@@ -710,7 +782,8 @@ async def poll_once(ceo_list: list[str], dry_run: bool):
 
     db = Session()
     try:
-        proc = DataProcessor()
+        proc         = DataProcessor()
+        stocks_cache = {}
         new_signal_count = 0
 
         for ceo in ceo_list:
@@ -747,11 +820,11 @@ async def poll_once(ceo_list: list[str], dry_run: bool):
                 )
 
                 for _, row in new_df.iterrows():
-                    if not passes_gates(row, eng_threshold):
+                    if not passes_gates(row, eng_threshold, ceo):
                         log.debug("  tweet failed gates, skip")
                         continue
 
-                    signal = evaluate_tweet(row, ceo, db)
+                    signal = evaluate_tweet(row, ceo, db, proc=proc, stocks_cache=stocks_cache)
                     if signal is None:
                         continue
 
@@ -824,6 +897,7 @@ async def run(ceo_list: list[str], dry_run: bool, interval_override: int | None,
         log.info("DRY-RUN mode — signals will be evaluated but no orders placed")
 
     _queued_open_processed = False
+    _last_full_poll_et     = None  # tracks when we last ran the full account sweep
 
     while True:
         now_et = datetime.now(ET)
@@ -836,20 +910,41 @@ async def run(ceo_list: list[str], dry_run: bool, interval_override: int | None,
         elif status != "open":
             _queued_open_processed = False
 
-        # Poll — DB-only skips Twitter entirely
-        if db_only:
-            poll_from_db(ceo_list, dry_run)
+        # Two-tier polling during market hours:
+        #   Fast lane  (every 3 min)  — HIGH_PRIORITY_HANDLES only
+        #   Full sweep (every 20 min) — all accounts
+        # Outside market hours we always do a full sweep at the slower cadence.
+        if status == "open" and not interval_override:
+            full_due = (
+                _last_full_poll_et is None
+                or (now_et - _last_full_poll_et).total_seconds() >= POLL_MARKET_HOURS_S
+            )
+            if full_due:
+                poll_list = ceo_list
+                _last_full_poll_et = now_et
+                log.info("Full sweep (%d accounts)", len(poll_list))
+            else:
+                poll_list = [c for c in ceo_list if c in HIGH_PRIORITY_HANDLES]
+                if poll_list:
+                    log.info("Fast-lane poll (%d HP accounts: %s)",
+                             len(poll_list), ", ".join(poll_list))
         else:
-            await poll_once(ceo_list, dry_run)
+            poll_list = ceo_list
+
+        if poll_list:
+            if db_only:
+                poll_from_db(poll_list, dry_run)
+            else:
+                await poll_once(poll_list, dry_run)
 
         if once:
             break
 
-        # Dynamic sleep
+        # Sleep duration
         if interval_override:
             sleep_s = interval_override
         elif status == "open":
-            sleep_s = POLL_MARKET_HOURS_S
+            sleep_s = POLL_HIGH_PRIORITY_S   # wake every 3 min; full sweep governed by _last_full_poll_et
         elif status in ("pre", "post"):
             sleep_s = POLL_EXTENDED_S
         else:

--- a/watch.py
+++ b/watch.py
@@ -86,6 +86,12 @@ CONF_SIZING_CEILING = 90.0   # confidence at/above which the confidence factor m
 MAX_OPEN_POSITIONS = int(os.getenv("MAX_OPEN_POSITIONS", "15"))
 MAX_DAILY_LOSS     = float(os.getenv("MAX_DAILY_LOSS", "1500"))  # halt new entries past this loss
 
+# ── Congressional trades (ingested by congress_ingest.py into congress_trades) ──
+# Only act on disclosures filed within this many days, so the first poll doesn't
+# trade the entire recent backlog. The signal is the disclosure becoming public.
+CONGRESS_RECENCY_DAYS = int(os.getenv("CONGRESS_RECENCY_DAYS", "4"))
+CONGRESS_CONFIDENCE   = 80.0
+
 ET = ZoneInfo("America/New_York")
 
 # ---------------------------------------------------------------------------
@@ -152,11 +158,32 @@ CREATE TABLE IF NOT EXISTS managed_positions (
 """
 
 
+_CONGRESS_TRADES_DDL = """
+CREATE TABLE IF NOT EXISTS congress_trades (
+    id              SERIAL PRIMARY KEY,
+    dedup_key       TEXT UNIQUE,
+    chamber         TEXT,
+    member          TEXT,
+    ticker          TEXT,
+    asset_type      TEXT,
+    txn_type        TEXT,
+    direction       TEXT,
+    txn_date        TEXT,
+    disclosure_date TEXT,
+    amount          TEXT,
+    owner           TEXT,
+    ingested_at     TIMESTAMPTZ DEFAULT NOW(),
+    processed       BOOLEAN DEFAULT FALSE
+);
+"""
+
+
 def init_db():
     with engine.connect() as conn:
         conn.execute(text(_WATCHER_STATE_DDL))
         conn.execute(text(_SIGNAL_QUEUE_DDL))
         conn.execute(text(_MANAGED_POSITIONS_DDL))
+        conn.execute(text(_CONGRESS_TRADES_DDL))
         conn.commit()
 
 
@@ -1005,6 +1032,76 @@ def poll_from_db(ceo_list: list[str], dry_run: bool):
 
 
 # ---------------------------------------------------------------------------
+# Congressional trades — trade newly disclosed filings from congress_trades
+# (populated by congress_ingest.py). Structured data: ticker + direction are
+# explicit, so this bypasses the registry/ML entirely, like the tweet fast-path.
+# ---------------------------------------------------------------------------
+
+def poll_congress_trades(dry_run: bool):
+    now_et = datetime.now(ET)
+    status = market_status(now_et)
+    cutoff = (now_et.date() - timedelta(days=CONGRESS_RECENCY_DAYS)).isoformat()
+
+    db = Session()
+    try:
+        rows = db.execute(
+            text("""
+                SELECT id, chamber, member, ticker, direction, txn_type,
+                       disclosure_date, amount
+                FROM congress_trades
+                WHERE processed = FALSE AND disclosure_date >= :cutoff
+                ORDER BY disclosure_date ASC
+            """),
+            {"cutoff": cutoff},
+        ).fetchall()
+
+        # Retire disclosures too old to act on so they don't linger unprocessed.
+        db.execute(
+            text("""
+                UPDATE congress_trades SET processed = TRUE
+                WHERE processed = FALSE AND disclosure_date < :cutoff
+            """),
+            {"cutoff": cutoff},
+        )
+
+        if not rows:
+            db.commit()
+            return
+
+        log.info("Congress: %d newly disclosed trade(s) to act on", len(rows))
+        for r in rows:
+            sig = {
+                "ceo":        f"congress:{r.member}"[:64],
+                "tweet_text": f"{r.member} {r.txn_type} {r.ticker} ({r.amount}) disclosed {r.disclosure_date}",
+                "tweet_date": r.disclosure_date,
+                "topic":      "congressional_trade",
+                "ticker":     r.ticker,
+                "tightness":  1.0,
+                "direction":  r.direction,
+                "confidence": CONGRESS_CONFIDENCE,
+                "sentiment":  0.0,
+                "finbert":    None,
+            }
+            if status == "open":
+                log.info("  CONGRESS %s → %s %s [MARKET OPEN — trading]",
+                         r.member, r.direction, r.ticker)
+                _execute_signal(sig, db, dry_run)
+            else:
+                log.info("  CONGRESS %s → %s %s [market %s — queuing]",
+                         r.member, r.direction, r.ticker, status)
+                enqueue_signal(db, sig)
+            db.execute(text("UPDATE congress_trades SET processed = TRUE WHERE id = :id"),
+                       {"id": r.id})
+
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        log.error("Congress poll error: %s", e)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # One polling cycle (Twitter mode)
 # ---------------------------------------------------------------------------
 
@@ -1171,6 +1268,9 @@ async def run(ceo_list: list[str], dry_run: bool, interval_override: int | None,
                 poll_from_db(poll_list, dry_run)
             else:
                 await poll_once(poll_list, dry_run)
+
+        # Trade newly disclosed congressional filings (from congress_ingest.py)
+        poll_congress_trades(dry_run)
 
         # Close any positions that have reached their next-day exit horizon
         close_due_positions(dry_run)


### PR DESCRIPTION
## Summary

Completes the in-progress signal-source expansion and hardens the trading pipeline end to end. Five themed commits:

1. **Congressional + policy signal sources, twikit migration, two-tier polling** — new account types, Twitter client moved from tweety-ns → twikit (cookie auth), Alpaca data-key fallback so both workflows work.
2. **Tier 1 — scheduled exits, short-seller fast-path, double-trade guard** — positions now close at the next-day horizon (`managed_positions`); short-seller reports get a fixed DOWN fast-path; idempotency guard prevents the Render worker + GitHub Actions from double-trading.
3. **Tier 2 — conviction-scaled position sizing + portfolio risk caps** — size scales with confidence × tightness; `MAX_OPEN_POSITIONS` and a `MAX_DAILY_LOSS` kill switch gate new entries.
4. **Fail loudly on broken Twitter auth + document cookie setup** — silent auth failure had frozen tweet ingestion for ~7 months; ingestion now errors visibly and the README documents cookie setup.
5. **Congressional trades from official disclosures (FMP), Twitter-free** — `congress_ingest.py` pulls structured House/Senate disclosures into `congress_trades`; the watcher trades them through the existing execution path. No Twitter, no PDF parsing, ~6 free API calls/day.

## Notable changes

- New: `congress_ingest.py`, `.github/workflows/congress-ingest.yml`, `test_twitter_cookies.py`, `22Features.md`
- New tables: `managed_positions`, `congress_trades`
- Removed `quiver_quant` (suspended on X); dead env vars cleaned from config

## Verification

- All 116 tests pass
- `congress_ingest.py` verified live: ingested 144 real disclosures; dedup + recency gate confirmed
- Imports, sizing curve, exit-horizon, and gate-bypass logic smoke-tested

## Deploy notes (require user action)

- Add `FMP_API_KEY` as a GitHub secret (congressional ingest is live-ready today, no cookies needed)
- Generate `twitter_cookies.json` + `TWITTER_COOKIES` secret to re-enable the tweet-based signals (CEO sentiment, short-seller, policy)
- First live run has an 88-trade congressional backlog within the recency window; `MAX_OPEN_POSITIONS=15` caps it, or set `CONGRESS_RECENCY_DAYS=1` to ease in

🤖 Generated with [Claude Code](https://claude.com/claude-code)