### PR TITLE
fix: run Render watcher worker in --db-only mode

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,16 +35,19 @@ services:
       - key: ALPHA_VANTAGE_API_KEY
         sync: false
 
-  # Always-on tweet watcher — polls every 20 min during market hours,
-  # 60 min pre/post market, 4 hours overnight. Queues signals found outside
-  # market hours and executes them at next open.
-  # Requires at least the Starter plan on Render.
+  # Always-on watcher — runs continuously so the next-day exit window and
+  # intraday signals are caught reliably (GitHub Actions cron drops most ticks).
+  # Runs in --db-only mode: it trades congressional disclosures (congress_trades),
+  # processes the signal queue, and closes positions at their exit horizon without
+  # needing Twitter cookies. Drop --db-only once twitter_cookies.json is supplied
+  # to also fetch live tweets.
+  # Requires at least the Starter plan on Render (free workers spin down).
   - type: worker
     name: tweet-watcher
     runtime: python
     plan: starter
     buildCommand: pip install -r requirements.txt
-    startCommand: python3 watch.py
+    startCommand: python3 watch.py --db-only
     envVars:
       - key: DATABASE_URL
         sync: false


### PR DESCRIPTION
## Why

Diagnosing why the scheduled next-day exits didn't fire, I found the **Render `tweet-watcher` worker is not running** — the only DB poll in the last 6 hours matched the single GitHub Actions run, with no continuous-worker heartbeat. All watcher activity is coming from GitHub Actions cron, which drops most scheduled ticks (the "every 20 min" cron is effectively running every ~2 hours) and missed the 19:30–19:55 UTC exit window entirely, so 15 positions are stuck open past their horizon.

## Change

`watch.py --db-only` for the worker start command. The old `python3 watch.py` ran in live Twitter mode, which throws auth errors every loop without cookies. `--db-only` skips Twitter and still:
- trades congressional disclosures (`congress_trades`),
- processes the signal queue,
- closes positions at their next-day exit horizon.

A continuously running worker is what makes the exit window reliable. Drop `--db-only` later once Twitter cookies are supplied.

## Still required (dashboard action — can't be done from code)

The worker service must actually be **deployed and running on Render** (Starter plan; free workers spin down) with its env vars set. This PR only fixes the config for when it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)